### PR TITLE
Normalize Part tool_call/tool_output content after deserialization

### DIFF
--- a/examples/structured_flows/tool_call_flow.py
+++ b/examples/structured_flows/tool_call_flow.py
@@ -72,7 +72,7 @@ def main():
     if last_item:
         for part in last_item.parts:
             if part.type == "tool_output":
-                res = part.content.result if hasattr(part.content, "result") else part.content.get("result")
+                res = part.as_tool_output().result
                 print(f"✅ Success! Tool Output: {res}")
             elif part.type == "error":
                 msg = part.content.message if hasattr(part.content, "message") else part.content.get("message")

--- a/protolink/agents/base.py
+++ b/protolink/agents/base.py
@@ -803,18 +803,9 @@ class Agent:
             - error: Error information (on failure)
         """
 
-        if hasattr(part.content, "tool_name"):
-            # Handle the dataclass object (in-memory execution)
-            tool_name = part.content.tool_name
-            args = part.content.args
-            call_id = part.content.call_id
-            self._logger.debug(f"Executing tool: {tool_name}")
-        else:
-            # Handle the dictionary (network/JSON execution)
-            tool_name = part.content.get("tool_name")
-            args = part.content.get("args", {})
-            call_id = part.content.get("call_id")
-            self._logger.debug(f"Executing tool: {tool_name}")
+        tc = part.as_tool_call()
+        tool_name, args, call_id = tc.tool_name, tc.args, tc.call_id
+        self._logger.debug(f"Executing tool: {tool_name}")
 
         tool = self.tools.get(tool_name)
         if not tool:

--- a/protolink/core/part.py
+++ b/protolink/core/part.py
@@ -54,6 +54,33 @@ class Part:
     type: PartType
     content: Any
 
+    @staticmethod
+    def _hydrate_content(part_type: PartType, content: Any) -> Any:
+        if content is None:
+            return content
+
+        if part_type == "tool_call":
+            if isinstance(content, ToolCall):
+                return content
+            if isinstance(content, dict):
+                return ToolCall(
+                    tool_name=content["tool_name"],
+                    args=content.get("args", {}),
+                    call_id=content.get("call_id", IDGenerator.generate_tool_call_id()),
+                )
+
+        if part_type == "tool_output":
+            if isinstance(content, ToolOutput):
+                return content
+            if isinstance(content, dict):
+                return ToolOutput(
+                    call_id=content.get("call_id", IDGenerator.generate_tool_output_id()),
+                    result=content.get("result"),
+                    error=content.get("error"),
+                )
+
+        return content
+
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary."""
         content = asdict(self.content) if hasattr(self.content, "__dataclass_fields__") else self.content
@@ -65,7 +92,9 @@ class Part:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "Part":
         """Create from dictionary."""
-        return cls(**data)
+        part_type = data["type"]
+        content = cls._hydrate_content(part_type, data.get("content"))
+        return cls(type=part_type, content=content)
 
     @classmethod
     def text(cls, content: str) -> "Part":

--- a/protolink/core/part.py
+++ b/protolink/core/part.py
@@ -96,6 +96,24 @@ class Part:
         content = cls._hydrate_content(part_type, data.get("content"))
         return cls(type=part_type, content=content)
 
+    def as_tool_call(self) -> ToolCall:
+        if self.type != "tool_call":
+            raise ValueError(f"Expected part type 'tool_call', got '{self.type}'")
+        if isinstance(self.content, ToolCall):
+            return self.content
+        if isinstance(self.content, dict):
+            return self._hydrate_content("tool_call", self.content)
+        raise TypeError(f"Unexpected tool_call content type: {type(self.content)}")
+
+    def as_tool_output(self) -> ToolOutput:
+        if self.type != "tool_output":
+            raise ValueError(f"Expected part type 'tool_output', got '{self.type}'")
+        if isinstance(self.content, ToolOutput):
+            return self.content
+        if isinstance(self.content, dict):
+            return self._hydrate_content("tool_output", self.content)
+        raise TypeError(f"Unexpected tool_output content type: {type(self.content)}")
+
     @classmethod
     def text(cls, content: str) -> "Part":
         """Create a text part (convenience method)."""

--- a/tests/test_part.py
+++ b/tests/test_part.py
@@ -51,11 +51,12 @@ async def test_execute_tool_with_deserialized_part():
     """Simulates network path: tool_call arrives as dict via from_dict."""
 
     class EchoTool(BaseTool):
-        name = "echo"
-        description = "echo"
-        input_schema = {}
-        output_schema = {}
-        tags: list[str] = []
+        def __init__(self):
+            self.name = "echo"
+            self.description = "echo"
+            self.input_schema = {}
+            self.output_schema = {}
+            self.tags = []
 
         async def __call__(self, **kwargs):
             return kwargs.get("msg", "")
@@ -71,4 +72,3 @@ async def test_execute_tool_with_deserialized_part():
     assert result.type == "tool_output"
     assert result.as_tool_output().result == "ping"
     assert result.as_tool_output().call_id == "c1"
-

--- a/tests/test_part.py
+++ b/tests/test_part.py
@@ -1,0 +1,74 @@
+"""Tests for Part serialization and content accessors."""
+
+import pytest
+
+from protolink.agents import Agent
+from protolink.core.agent_card import AgentCard
+from protolink.core.part import Part, ToolCall, ToolOutput
+from protolink.tools import BaseTool
+
+
+def test_tool_call_roundtrip():
+    original = Part.tool_call(tool_name="add", args={"a": 1, "b": 2}, call_id="call_abc")
+    restored = Part.from_dict(original.to_dict())
+    tc = restored.as_tool_call()
+    assert isinstance(tc, ToolCall)
+    assert tc.tool_name == "add"
+    assert tc.args == {"a": 1, "b": 2}
+    assert tc.call_id == "call_abc"
+
+
+def test_tool_output_roundtrip():
+    original = Part.tool_output(call_id="call_abc", result=42)
+    restored = Part.from_dict(original.to_dict())
+    out = restored.as_tool_output()
+    assert isinstance(out, ToolOutput)
+    assert out.call_id == "call_abc"
+    assert out.result == 42
+
+
+def test_from_dict_hydrates_tool_call():
+    data = {"type": "tool_call", "content": {"tool_name": "echo", "args": {"msg": "hi"}, "call_id": "x1"}}
+    part = Part.from_dict(data)
+    assert isinstance(part.content, ToolCall)
+    assert part.as_tool_call().tool_name == "echo"
+
+
+def test_from_dict_hydrates_tool_output():
+    data = {"type": "tool_output", "content": {"call_id": "x1", "result": 42}}
+    part = Part.from_dict(data)
+    assert isinstance(part.content, ToolOutput)
+    assert part.as_tool_output().result == 42
+
+
+def test_as_tool_call_wrong_type_raises():
+    with pytest.raises(ValueError, match="tool_call"):
+        Part.text("hello").as_tool_call()
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_with_deserialized_part():
+    """Simulates network path: tool_call arrives as dict via from_dict."""
+
+    class EchoTool(BaseTool):
+        name = "echo"
+        description = "echo"
+        input_schema = {}
+        output_schema = {}
+        tags: list[str] = []
+
+        async def __call__(self, **kwargs):
+            return kwargs.get("msg", "")
+
+    card = AgentCard(name="t", description="t", url="http://t.local")
+    agent = Agent(card, transport="runtime")
+    agent.tools["echo"] = EchoTool()
+
+    raw = {"type": "tool_call", "content": {"tool_name": "echo", "args": {"msg": "ping"}, "call_id": "c1"}}
+    part = Part.from_dict(raw)
+    result = await agent.execute_tool(part)
+
+    assert result.type == "tool_output"
+    assert result.as_tool_output().result == "ping"
+    assert result.as_tool_output().call_id == "c1"
+


### PR DESCRIPTION
## Summary

* Add `Part._hydrate_content()` and wire it into `Part.from_dict()` so deserialized `tool_call` and `tool_output` parts become `ToolCall` / `ToolOutput` dataclasses, matching the shape produced by `Part.tool_call()`.
* Add `Part.as_tool_call()` and `Part.as_tool_output()` accessors for typed, validated content access.
* Simplify `Agent.execute_tool()` to use `as_tool_call()` instead of dict/dataclass branching.
* Add `tests/test_part.py` covering roundtrips, hydration, accessor validation, and deserialized tool execution.
* Update `tool_call_flow.py` to use `as_tool_output()`.

## Problem

`Part.tool_call()` stores content as a `ToolCall` dataclass, but `Part.from_dict()` left content as a raw dictionary after JSON/network roundtrips. As a result, consumers such as `execute_tool()` had to handle both representations:

```python
if hasattr(part.content, "tool_name"):
    ...
else:
    part.content.get("tool_name")
```

The same inconsistency existed for `tool_output` content.

## Solution

Centralize tool content hydration in `Part.from_dict()` and expose typed accessors on `Part`. This restores a consistent representation across in-memory and deserialized objects while simplifying downstream code.

`call_llm()` prompt extraction is unchanged since infer content remains dictionary-based.

## Test Plan

* [x] `pytest tests/test_part.py -v`
* [x] `pytest tests/test_agent.py -v`
* [x] `ruff check tests/test_part.py`
* [x] `ty check tests/test_part.py protolink/core/part.py`