### PR TITLE
Transport Config

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
 include LICENSE
 include README.md
-include requirements/*.txt
-recursive-include docs *.rst *.txt
+prune docs/build
+prune docs/node_modules

--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ transport = HTTPTransport(
 agent = Agent(card=card, transport=transport)
 ```
 
-This keeps Agent concerns such as reasoning, tools, state, and policy separate from transport concerns such as TLS, payload limits, retries, keepalive, and connection management. Agent and Registry transports can therefore use different certificates and capacity policies without expanding or coupling the `Agent` constructor.
+This keeps Agent concerns such as reasoning, tools, state, and policy separate from transport concerns such as TLS, payload limits, retries, keepalive, and connection management. The same rule applies to `AgentClient` and `Registry`: pass a string for defaults or a configured transport object for advanced behavior. Every service boundary can therefore use its own certificates and capacity policy without expanding or coupling the high-level constructors.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -295,6 +295,53 @@ When using an HTTP-compatible transport (`http`, `sse`, `json-rpc`, or `sse-json
   </tr>
 </table>
 
+## API Design
+
+ProtoLink's core philosophy is a **simple API with progressive control**: the shortest path should be enough for prototyping, while production features remain available through explicit, composable objects instead of adding every advanced option to `Agent`.
+
+For a fast prototype, pass a transport name. ProtoLink builds the transport with safe defaults:
+
+```python
+from protolink import Agent, AgentCard
+
+card = AgentCard(
+    name="assistant",
+    description="General-purpose assistant",
+    url="http://127.0.0.1:8000",
+)
+
+agent = Agent(card=card, transport="http")
+```
+
+For production, configure the transport directly and pass the completed object to the same Agent API:
+
+```python
+from protolink import Agent, AgentCard, RetryPolicy, TLSConfig, TransportConfig, TransportLimits
+from protolink.transport import HTTPTransport
+
+card = AgentCard(
+    name="assistant",
+    description="Production assistant",
+    url="https://agent.internal:8443",
+)
+transport = HTTPTransport(
+    url=card.url,
+    tls=TLSConfig(
+        certfile="certs/agent.pem",
+        keyfile="certs/agent-key.pem",
+        cafile="certs/ca.pem",
+    ),
+    config=TransportConfig(
+        limits=TransportLimits(max_concurrent_requests=200),
+        retry=RetryPolicy(max_attempts=3),
+    ),
+)
+
+agent = Agent(card=card, transport=transport)
+```
+
+This keeps Agent concerns such as reasoning, tools, state, and policy separate from transport concerns such as TLS, payload limits, retries, keepalive, and connection management. Agent and Registry transports can therefore use different certificates and capacity policies without expanding or coupling the `Agent` constructor.
+
 ## Documentation
 
 Follow the API documentation here: [Documentation](https://nmaroulis.github.io/protolink/)
@@ -312,10 +359,11 @@ For Agent-to-Agent & Agent-to-Registry communication:
 - `grpc` · [GRPCTransport](https://github.com/nMaroulis/protolink/blob/main/protolink/transport/grpc_transport.py): Uses gRPC unary calls and unary-stream task events over compact JSON envelopes. [`grpcio`]
 - `runtime` · [RuntimeTransport](https://github.com/nMaroulis/protolink/blob/main/protolink/transport/runtime_transport.py): Simple **in-process, in-memory transport**.
 
-All network transports share one native TLS API. Use `https://`, `wss://`, or `grpcs://` and pass `TLSConfig` at the top level:
+All network transports share one native TLS API. Use `https://`, `wss://`, or `grpcs://` and configure `TLSConfig` on the transport:
 
 ```python
 from protolink import Agent, AgentCard, TLSConfig
+from protolink.transport import HTTPTransport
 
 tls = TLSConfig(
     certfile="certs/agent.pem",
@@ -324,15 +372,16 @@ tls = TLSConfig(
     # require_client_cert=True,  # enable mutual TLS
 )
 
-agent = Agent(
-    card=AgentCard(
-        name="secure-agent",
-        description="Agent served over HTTPS",
-        url="https://agent.internal:8443",
-    ),
-    transport="http",
+card = AgentCard(
+    name="secure-agent",
+    description="Agent served over HTTPS",
+    url="https://agent.internal:8443",
+)
+transport = HTTPTransport(
+    url=card.url,
     tls=tls,
 )
+agent = Agent(card=card, transport=transport)
 ```
 
 `TLSConfig` encrypts the connection and verifies certificates; `Authenticator` implementations handle application credentials and authorization. They are independent and can be combined. See the [TLS and mutual TLS guide](https://nmaroulis.github.io/protolink/docs/transport/#tls-and-mutual-tls) and [`examples/tls_agent.py`](https://github.com/nMaroulis/protolink/blob/main/examples/tls_agent.py).
@@ -340,18 +389,21 @@ agent = Agent(
 All transports also share one production configuration surface:
 
 ```python
-from protolink import RetryPolicy, TransportConfig, TransportLimits
+from protolink import Agent, AgentCard, RetryPolicy, TransportConfig, TransportLimits
+from protolink.transport import HTTPTransport
 
+agent_card = AgentCard(
+    name="production-agent",
+    description="Production task worker",
+    url="http://127.0.0.1:8000",
+)
 transport_config = TransportConfig(
     limits=TransportLimits(max_concurrent_requests=200, max_concurrent_streams=50),
     retry=RetryPolicy(max_attempts=3),
 )
 
-agent = Agent(
-    card=agent_card,
-    transport="grpc",
-    transport_config=transport_config,
-)
+transport = HTTPTransport(url=agent_card.url, config=transport_config)
+agent = Agent(card=agent_card, transport=transport)
 ```
 
 Retries remain off by default and run only for explicitly idempotent request specifications. Correlation IDs, server-side idempotency replay, bounded payloads/concurrency, loop-safe pooled-resource shutdown, WebSocket keepalive, typed transport errors, local metric snapshots, and `/healthz` and `/readyz` probes use the same contract across HTTP, SSE JSON-RPC, WebSocket, gRPC, and RuntimeTransport. The `grpc` extra also installs standard gRPC health checking and reflection. See the [production transport guide](https://nmaroulis.github.io/protolink/docs/transport/#production-configuration) and [`examples/transport_production.py`](https://github.com/nMaroulis/protolink/blob/main/examples/transport_production.py).

--- a/README.md
+++ b/README.md
@@ -356,6 +356,8 @@ agent = Agent(
 
 Retries remain off by default and run only for explicitly idempotent request specifications. Correlation IDs, server-side idempotency replay, bounded payloads/concurrency, loop-safe pooled-resource shutdown, WebSocket keepalive, typed transport errors, local metric snapshots, and `/healthz` and `/readyz` probes use the same contract across HTTP, SSE JSON-RPC, WebSocket, gRPC, and RuntimeTransport. The `grpc` extra also installs standard gRPC health checking and reflection. See the [production transport guide](https://nmaroulis.github.io/protolink/docs/transport/#production-configuration) and [`examples/transport_production.py`](https://github.com/nMaroulis/protolink/blob/main/examples/transport_production.py).
 
+These controls exist so changing protocols does not change the Agent's production safety model. Limits prevent one payload or traffic burst from exhausting the process; retries recover explicitly safe operations from temporary connection failures; idempotency prevents those retries from executing the same operation twice; and metrics and health probes make the behavior visible. The defaults are suitable for getting started and do not enable retries automatically.
+
 The application-facing transport types are exported directly from `protolink`:
 
 | API | Purpose |

--- a/README.md
+++ b/README.md
@@ -337,6 +337,37 @@ agent = Agent(
 
 `TLSConfig` encrypts the connection and verifies certificates; `Authenticator` implementations handle application credentials and authorization. They are independent and can be combined. See the [TLS and mutual TLS guide](https://nmaroulis.github.io/protolink/docs/transport/#tls-and-mutual-tls) and [`examples/tls_agent.py`](https://github.com/nMaroulis/protolink/blob/main/examples/tls_agent.py).
 
+All transports also share one production configuration surface:
+
+```python
+from protolink import RetryPolicy, TransportConfig, TransportLimits
+
+transport_config = TransportConfig(
+    limits=TransportLimits(max_concurrent_requests=200, max_concurrent_streams=50),
+    retry=RetryPolicy(max_attempts=3),
+)
+
+agent = Agent(
+    card=agent_card,
+    transport="grpc",
+    transport_config=transport_config,
+)
+```
+
+Retries remain off by default and run only for explicitly idempotent request specifications. Correlation IDs, server-side idempotency replay, bounded payloads/concurrency, loop-safe pooled-resource shutdown, WebSocket keepalive, typed transport errors, local metric snapshots, and `/healthz` and `/readyz` probes use the same contract across HTTP, SSE JSON-RPC, WebSocket, gRPC, and RuntimeTransport. The `grpc` extra also installs standard gRPC health checking and reflection. See the [production transport guide](https://nmaroulis.github.io/protolink/docs/transport/#production-configuration) and [`examples/transport_production.py`](https://github.com/nMaroulis/protolink/blob/main/examples/transport_production.py).
+
+The application-facing transport types are exported directly from `protolink`:
+
+| API | Purpose |
+|-----|---------|
+| `TransportConfig` | One immutable configuration for limits, retries, keepalive, shutdown, idempotency replay, and metrics. |
+| `TransportLimits` | Request, response, stream-event, request-concurrency, and stream-concurrency bounds. |
+| `RetryPolicy` | Explicit attempt count, exponential backoff, jitter, and retryable method set. |
+| `TransportMetricsSnapshot` | Dependency-free per-instance counters, byte totals, active work, retries, and cumulative latency. |
+| `TransportError` and typed subclasses | Stable connection, timeout, protocol, remote, and payload-limit failures with request metadata. |
+
+Transport authors can additionally import `Transport`, `TransportCapabilities`, and `TransportRequestContext` from `protolink.transport`. The [shared API reference](https://nmaroulis.github.io/protolink/docs/transport/#shared-transport-api-reference) lists every field, default, base-class hook, health payload, and protocol mapping.
+
 #### LLMs:
 
 Protolink separates LLMs into three types: `api`, `local`, and `server`.

--- a/docs/content/agent.md
+++ b/docs/content/agent.md
@@ -245,6 +245,8 @@ agent = Agent(card=card, transport=transport, llm=llm)
 
 Pass one `TransportConfig` at the Agent boundary when the Agent creates transports from string aliases. The same object configures the Agent's server/client transport and any registry transport created from `registry="..."`:
 
+An Agent uses its transport in both directions: its server receives tasks from peers, and its client sends tasks to peers. Using one configuration means both directions agree on payload bounds, retry safety, connection lifecycle, and metrics. The registry connection receives the same policy so discovery traffic does not quietly behave differently from Agent traffic.
+
 ```python
 from protolink import Agent, RetryPolicy, TransportConfig, TransportLimits
 
@@ -269,6 +271,10 @@ agent = Agent(
 ```
 
 When `transport` or `registry` is already an object, its own `config` remains authoritative. Inspect the active instance through `agent.transport`; its `config`, `capabilities`, `metrics`, and `health()` surfaces are documented in the [transport reference](./transport.md#shared-transport-api-reference).
+
+The configuration object may be shared, but each concrete transport still owns separate runtime state. Agent and Registry connections have their own pools, concurrency slots, idempotency caches, and metric counters. This prevents unrelated endpoints from sharing active-request gauges or cached responses merely because they use the same settings.
+
+For a first deployment, leaving `transport_config=None` is reasonable. Add explicit limits after measuring normal task sizes and concurrency, then enable retries only when the operations and downstream side effects are known to be idempotent.
 
 ### Durable Task Snapshots
 

--- a/docs/content/agent.md
+++ b/docs/content/agent.md
@@ -221,6 +221,7 @@ Unlike the original A2A specification, Protolink's `Agent` combines client and s
 | `authenticator` | `Authenticator ⎪ None` | `None` | Optional Authenticator instance for verifying incoming requests to this agent. |
 | `credentials` | `str ⎪ None` | `None` | Optional credentials string used for authenticating outgoing requests. |
 | `tls` | `TLSConfig ⎪ None` | `None` | Optional transport-security configuration propagated to factory-created agent and registry transports. Use with `https://`, `wss://`, or `grpcs://` URLs. |
+| `transport_config` | `TransportConfig ⎪ None` | `None` | Shared limits, retry, keepalive, graceful shutdown, idempotency cache, and local metrics configuration propagated to factory-created agent and registry transports. |
 | `policy` | `Policy ⎪ None` | `None` | Runtime action policy. Defaults to an allow-by-default `CapabilityPolicy`. |
 | `approval_handler` | `Callable ⎪ None` | `None` | Application callback that resolves typed `ApprovalRequest` checkpoints. |
 | `run_store` | `RunStore ⎪ None` | `None` | Optional durable task/run store. When provided, the default runtime records task snapshots after direct, server, and streaming execution paths. |
@@ -239,6 +240,35 @@ transport = HTTPTransport(url=url)
 
 agent = Agent(card=card, transport=transport, llm=llm)
 ```
+
+### Production Transport Configuration
+
+Pass one `TransportConfig` at the Agent boundary when the Agent creates transports from string aliases. The same object configures the Agent's server/client transport and any registry transport created from `registry="..."`:
+
+```python
+from protolink import Agent, RetryPolicy, TransportConfig, TransportLimits
+
+transport_config = TransportConfig(
+    limits=TransportLimits(
+        max_request_bytes=8 * 1024 * 1024,
+        max_response_bytes=8 * 1024 * 1024,
+        max_concurrent_requests=200,
+        max_concurrent_streams=50,
+    ),
+    retry=RetryPolicy(max_attempts=3),
+    shutdown_timeout=10.0,
+)
+
+agent = Agent(
+    card=card,
+    transport="grpc",
+    registry="http",
+    registry_url="http://registry.internal:9000",
+    transport_config=transport_config,
+)
+```
+
+When `transport` or `registry` is already an object, its own `config` remains authoritative. Inspect the active instance through `agent.transport`; its `config`, `capabilities`, `metrics`, and `health()` surfaces are documented in the [transport reference](./transport.md#shared-transport-api-reference).
 
 ### Durable Task Snapshots
 

--- a/docs/content/agent.md
+++ b/docs/content/agent.md
@@ -204,7 +204,7 @@ Unlike the original A2A specification, Protolink's `Agent` combines client and s
 | Parameter | Type | Default | Description |
 |-----------|-----|---------|-------------|
 | `card` | `AgentCard ⎪ dict` | - | **Required.** The agent's metadata card containing name, description, and other identifying information. |
-| `transport` | `Transport ⎪ str ⎪ None` | `None` | Optional transport for communication. Can be a Transport instance or a string alias (e.g. "http", "runtime"). If not provided, you must set one later via the `transport` property. |
+| `transport` | `Transport ⎪ str ⎪ None` | `None` | Transport instance or simple string alias such as `"http"` or `"runtime"`. String aliases use default transport settings; pass a configured object for TLS, limits, retries, or protocol-specific options. |
 | `registry` | `Registry ⎪ RegistryClient ⎪ str ⎪ None` | `None` | Optional registry for agent discovery. Can be a Registry instance, RegistryClient, or URL string. |
 | `registry_url` | `str ⎪ None` | `None` | URL of the registry when using string transport type for registry creation. |
 | `llm` | `LLM ⎪ None` | `None` | Optional language model instance for the agent to use. |
@@ -220,8 +220,6 @@ Unlike the original A2A specification, Protolink's `Agent` combines client and s
 | `expose_chat` | `bool` | `True` | Whether an LLM-backed Agent will serve the interactive chat UI and accept chat messages. HTTP-compatible transports make this visible at `/chat`. |
 | `authenticator` | `Authenticator ⎪ None` | `None` | Optional Authenticator instance for verifying incoming requests to this agent. |
 | `credentials` | `str ⎪ None` | `None` | Optional credentials string used for authenticating outgoing requests. |
-| `tls` | `TLSConfig ⎪ None` | `None` | Optional transport-security configuration propagated to factory-created agent and registry transports. Use with `https://`, `wss://`, or `grpcs://` URLs. |
-| `transport_config` | `TransportConfig ⎪ None` | `None` | Shared limits, retry, keepalive, graceful shutdown, idempotency cache, and local metrics configuration propagated to factory-created agent and registry transports. |
 | `policy` | `Policy ⎪ None` | `None` | Runtime action policy. Defaults to an allow-by-default `CapabilityPolicy`. |
 | `approval_handler` | `Callable ⎪ None` | `None` | Application callback that resolves typed `ApprovalRequest` checkpoints. |
 | `run_store` | `RunStore ⎪ None` | `None` | Optional durable task/run store. When provided, the default runtime records task snapshots after direct, server, and streaming execution paths. |
@@ -241,15 +239,27 @@ transport = HTTPTransport(url=url)
 agent = Agent(card=card, transport=transport, llm=llm)
 ```
 
-### Production Transport Configuration
+### Simple and Advanced Transports
 
-Pass one `TransportConfig` at the Agent boundary when the Agent creates transports from string aliases. The same object configures the Agent's server/client transport and any registry transport created from `registry="..."`:
-
-An Agent uses its transport in both directions: its server receives tasks from peers, and its client sends tasks to peers. Using one configuration means both directions agree on payload bounds, retry safety, connection lifecycle, and metrics. The registry connection receives the same policy so discovery traffic does not quietly behave differently from Agent traffic.
+The Agent API uses progressive control. Pass a registered transport name when defaults are sufficient:
 
 ```python
-from protolink import Agent, RetryPolicy, TransportConfig, TransportLimits
+agent = Agent(card=card, transport="http", llm=llm)
+```
 
+This is the prototyping path: ProtoLink creates an `HTTPTransport` from `card.url`, applies safe default limits, collects local metrics, and leaves retries disabled.
+
+For TLS, resource policies, retries, or protocol-specific constructor options, build the transport explicitly:
+
+```python
+from protolink import Agent, AgentCard, RetryPolicy, TLSConfig, TransportConfig, TransportLimits
+from protolink.transport import GRPCTransport
+
+card = AgentCard(
+    name="production-agent",
+    description="Production task worker",
+    url="grpcs://agent.internal:9443",
+)
 transport_config = TransportConfig(
     limits=TransportLimits(
         max_request_bytes=8 * 1024 * 1024,
@@ -260,21 +270,27 @@ transport_config = TransportConfig(
     retry=RetryPolicy(max_attempts=3),
     shutdown_timeout=10.0,
 )
+transport = GRPCTransport(
+    url=card.url,
+    tls=TLSConfig(
+        certfile="certs/agent.pem",
+        keyfile="certs/agent-key.pem",
+        cafile="certs/ca.pem",
+    ),
+    config=transport_config,
+)
 
 agent = Agent(
     card=card,
-    transport="grpc",
-    registry="http",
-    registry_url="http://registry.internal:9000",
-    transport_config=transport_config,
+    transport=transport,
 )
 ```
 
-When `transport` or `registry` is already an object, its own `config` remains authoritative. Inspect the active instance through `agent.transport`; its `config`, `capabilities`, `metrics`, and `health()` surfaces are documented in the [transport reference](./transport.md#shared-transport-api-reference).
+`Agent` deliberately does not duplicate `tls=` or `transport_config=` arguments. TLS, limits, retries, keepalive, and connection ownership belong to the transport. This keeps the common Agent constructor small and lets the Agent transport and Registry transport use independent certificates and capacity policies.
 
-The configuration object may be shared, but each concrete transport still owns separate runtime state. Agent and Registry connections have their own pools, concurrency slots, idempotency caches, and metric counters. This prevents unrelated endpoints from sharing active-request gauges or cached responses merely because they use the same settings.
+An Agent uses its concrete transport in both directions: its server receives tasks from peers and its client sends tasks to peers. Inspect that instance through `agent.transport`; its `config`, `capabilities`, `metrics`, and `health()` surfaces are documented in the [transport reference](./transport.md#shared-transport-api-reference).
 
-For a first deployment, leaving `transport_config=None` is reasonable. Add explicit limits after measuring normal task sizes and concurrency, then enable retries only when the operations and downstream side effects are known to be idempotent.
+For an advanced Registry connection, construct its transport separately and wrap it in `RegistryClient`. Passing `registry="http"` remains the simple default path.
 
 ### Durable Task Snapshots
 

--- a/docs/content/authentication.md
+++ b/docs/content/authentication.md
@@ -196,7 +196,7 @@ When hosting an agent server, endpoints can be protected by configuring an `auth
 
 :::note[Authentication and TLS are different layers]
 
-An `Authenticator` decides whether an application request may access the agent. `TLSConfig` encrypts the network connection and verifies certificate identities before that request arrives. Use secure URL schemes with `tls=` for HTTPS, WSS, or secure gRPC, and combine TLS with an authenticator when you need both protected traffic and application authorization. See [TLS and mutual TLS](transport.md#tls-and-mutual-tls).
+An `Authenticator` decides whether an application request may access the agent. `TLSConfig` encrypts the network connection and verifies certificate identities before that request arrives. Configure `tls=` on an HTTP, SSE JSON-RPC, WebSocket, or gRPC transport with its secure URL scheme, then pass that transport to the Agent. Combine TLS with an authenticator when you need both protected traffic and application authorization. See [TLS and mutual TLS](transport.md#tls-and-mutual-tls).
 
 :::
 

--- a/docs/content/changelog.md
+++ b/docs/content/changelog.md
@@ -44,7 +44,7 @@ uv add --upgrade protolink
   - Added gRPC transport conformance and integration coverage plus the provider-free `examples/grpc_agent.py` example.
 - **TLS and mutual TLS**
   - Added the top-level `TLSConfig` API for shared certificate trust, server identity, and optional client-certificate verification across HTTP, SSE JSON-RPC, WebSocket, and gRPC.
-  - Added secure `https://`, `wss://`, and `grpcs://` URL handling. TLS is owned by concrete Agent transports, while `AgentClient` and `Registry` retain factory convenience arguments.
+  - Added secure `https://`, `wss://`, and `grpcs://` URL handling, with TLS owned consistently by concrete transport instances.
   - Added certificate-backed integration coverage and `examples/tls_agent.py`, while keeping transport encryption independent from application authentication and authorization.
 - **Shared production transport contract**
   - Added `TransportConfig`, `TransportLimits`, and `RetryPolicy` for consistent payload bounds, request/stream concurrency, explicit idempotent retries, keepalive, graceful shutdown, response deduplication, and dependency-free metrics across every built-in transport.
@@ -58,12 +58,16 @@ uv add --upgrade protolink
 
 ### Changed
 
-- Simplified the Agent API boundary: string transport aliases remain the zero-configuration prototyping path, while TLS, limits, retries, keepalive, and protocol-specific settings are configured on a concrete transport object passed to Agent.
-- `AgentClient` and `Registry` retain `tls=` and `transport_config=` factory conveniences because they directly own the transports they create. Agent serialization now restores its primary and Registry transports with independent TLS identities and production configurations.
+- Unified transport construction across `Agent`, `AgentClient`, and `Registry`: string aliases remain the zero-configuration prototyping path, while TLS, limits, retries, keepalive, and protocol-specific settings are configured on a concrete transport object passed to the facade.
+- Agent serialization now restores its primary and Registry transports with independent TLS identities and production configurations.
 - `ClientRequestSpec` now declares operation idempotency explicitly. Retries remain disabled by default and run only when the request specification, method, and typed failure all permit a safe retry.
 - HTTP, SSE JSON-RPC, WebSocket, gRPC, and RuntimeTransport now enforce the same serialized payload and concurrency contract, so in-process tests exercise the same resource boundaries as network deployments.
 - Correlation IDs remain stable across retry attempts, while idempotency keys suppress concurrent duplicate execution and replay completed responses within the configured process-local cache window.
 - Expanded the Transport, Agent, Client, Registry, and AgentCard documentation with complete signatures, defaults, protocol mappings, operational rationale, custom-transport guidance, and production examples. The documentation landing-page IDE now includes gRPC and production transport configuration with incremental line editing.
+
+### Removed
+
+- Removed facade-level `tls=` and `transport_config=` constructor arguments from `Agent`, `AgentClient`, and `Registry`. Advanced settings now have one owner and one API: the concrete transport instance.
 
 ### Fixed
 

--- a/docs/content/changelog.md
+++ b/docs/content/changelog.md
@@ -76,6 +76,12 @@ uv add --upgrade protolink
 - Fixed HTTP health probes so `/healthz` and `/readyz` remain available when application authentication is enabled.
 - Fixed transport shutdown across background-thread and caller event loops by closing pooled clients and channels on the event loop that owns them.
 - Fixed gRPC shutdown so loop-local cached channels are closed and removed correctly, including repeated `start()` and `stop()` calls.
+- Fixed HTTP and SSE server-side request/stream accounting so shared concurrency limits and transport metrics apply on both sides of a connection.
+- Fixed SSE terminal-frame parsing so the final task event is emitted exactly once.
+- Fixed failed or cancelled WebSocket and gRPC idempotent operations so they release waiting duplicates without poisoning the completed-response cache.
+- Fixed WebSocket pooling after timeouts, protocol corruption, and abandoned streams so unread frames cannot leak into a later request.
+- Fixed Agent configuration round trips so restored Registry transports retain the Agent's serialized authentication strategy and credentials.
+- Fixed short-lived SQLite storage, run-store, and doctor connections so every database handle closes deterministically after use.
 - Fixed source-distribution contents so generated Docusaurus output and `docs/node_modules` are excluded from PyPI packages.
 
 ## [0.6.4] - 2026-07-03

--- a/docs/content/changelog.md
+++ b/docs/content/changelog.md
@@ -44,7 +44,7 @@ uv add --upgrade protolink
   - Added gRPC transport conformance and integration coverage plus the provider-free `examples/grpc_agent.py` example.
 - **TLS and mutual TLS**
   - Added the top-level `TLSConfig` API for shared certificate trust, server identity, and optional client-certificate verification across HTTP, SSE JSON-RPC, WebSocket, and gRPC.
-  - Added secure `https://`, `wss://`, and `grpcs://` URL handling and automatic propagation through `Agent`, `AgentClient`, and `Registry` factory-created transports.
+  - Added secure `https://`, `wss://`, and `grpcs://` URL handling. TLS is owned by concrete Agent transports, while `AgentClient` and `Registry` retain factory convenience arguments.
   - Added certificate-backed integration coverage and `examples/tls_agent.py`, while keeping transport encryption independent from application authentication and authorization.
 - **Shared production transport contract**
   - Added `TransportConfig`, `TransportLimits`, and `RetryPolicy` for consistent payload bounds, request/stream concurrency, explicit idempotent retries, keepalive, graceful shutdown, response deduplication, and dependency-free metrics across every built-in transport.
@@ -58,7 +58,8 @@ uv add --upgrade protolink
 
 ### Changed
 
-- `Agent`, `AgentClient`, and `Registry` now accept `transport_config=` when constructing transports by name; directly supplied transport objects retain ownership of their existing configuration.
+- Simplified the Agent API boundary: string transport aliases remain the zero-configuration prototyping path, while TLS, limits, retries, keepalive, and protocol-specific settings are configured on a concrete transport object passed to Agent.
+- `AgentClient` and `Registry` retain `tls=` and `transport_config=` factory conveniences because they directly own the transports they create. Agent serialization now restores its primary and Registry transports with independent TLS identities and production configurations.
 - `ClientRequestSpec` now declares operation idempotency explicitly. Retries remain disabled by default and run only when the request specification, method, and typed failure all permit a safe retry.
 - HTTP, SSE JSON-RPC, WebSocket, gRPC, and RuntimeTransport now enforce the same serialized payload and concurrency contract, so in-process tests exercise the same resource boundaries as network deployments.
 - Correlation IDs remain stable across retry attempts, while idempotency keys suppress concurrent duplicate execution and replay completed responses within the configured process-local cache window.
@@ -71,6 +72,7 @@ uv add --upgrade protolink
 - Fixed HTTP health probes so `/healthz` and `/readyz` remain available when application authentication is enabled.
 - Fixed transport shutdown across background-thread and caller event loops by closing pooled clients and channels on the event loop that owns them.
 - Fixed gRPC shutdown so loop-local cached channels are closed and removed correctly, including repeated `start()` and `stop()` calls.
+- Fixed source-distribution contents so generated Docusaurus output and `docs/node_modules` are excluded from PyPI packages.
 
 ## [0.6.4] - 2026-07-03
 

--- a/docs/content/changelog.md
+++ b/docs/content/changelog.md
@@ -38,16 +38,39 @@ uv add --upgrade protolink
 
 ### Added
 
-- Added `GRPCTransport`, the `"grpc"` factory registration, gRPC transport conformance coverage, and `examples/grpc_agent.py` for provider-free request/response and streaming usage.
-- Added the top-level `TLSConfig` API with native TLS and optional mutual TLS for HTTP, SSE JSON-RPC, WebSocket, and gRPC transports; secure URL schemes; high-level `Agent`, `AgentClient`, and `Registry` propagation; certificate-backed integration coverage; and `examples/tls_agent.py`.
-- Added one top-level `TransportConfig` API for payload/concurrency limits, explicit idempotent retries, keepalive, graceful shutdown, response deduplication, and local metrics across every transport. `TransportCapabilities` and the public `TransportRequestContext` extension type are available from `protolink.transport`.
-- Added typed transport errors, correlation and idempotency propagation, loop-owned pooled-resource cleanup, idempotent transport lifecycle methods, `/healthz` and `/readyz`, WebSocket ping/pong configuration, and standard gRPC health/reflection services.
-- Added optional `AgentCard.interfaces` metadata for agents exposed through multiple transport endpoints, plus `examples/transport_production.py`.
+- **Native gRPC transport**
+  - Added `GRPCTransport` and the `"grpc"` factory alias for unary task requests, server-streaming task events, metadata-based credentials, deadlines, and pooled async channels.
+  - Added standard `grpc.health.v1.Health` reporting and server reflection, with constructor switches for deployments that disable either service.
+  - Added gRPC transport conformance and integration coverage plus the provider-free `examples/grpc_agent.py` example.
+- **TLS and mutual TLS**
+  - Added the top-level `TLSConfig` API for shared certificate trust, server identity, and optional client-certificate verification across HTTP, SSE JSON-RPC, WebSocket, and gRPC.
+  - Added secure `https://`, `wss://`, and `grpcs://` URL handling and automatic propagation through `Agent`, `AgentClient`, and `Registry` factory-created transports.
+  - Added certificate-backed integration coverage and `examples/tls_agent.py`, while keeping transport encryption independent from application authentication and authorization.
+- **Shared production transport contract**
+  - Added `TransportConfig`, `TransportLimits`, and `RetryPolicy` for consistent payload bounds, request/stream concurrency, explicit idempotent retries, keepalive, graceful shutdown, response deduplication, and dependency-free metrics across every built-in transport.
+  - Added `TransportCapabilities`, `TransportMetricsSnapshot`, and the public `TransportRequestContext` extension type for capability inspection, operational counters, correlation IDs, idempotency keys, and retry-attempt tracking.
+  - Added typed connection, timeout, protocol, remote, and payload-limit errors carrying URL, request ID, retryability, and protocol-native status metadata.
+  - Added `/healthz` and `/readyz` Agent and Registry probes, configurable WebSocket ping/pong behavior, loop-owned pooled-resource cleanup, and idempotent transport lifecycle methods.
+- **Multi-transport Agent metadata**
+  - Added optional `AgentCard.interfaces` / `AgentInterface` metadata so one Agent can advertise additional protocol endpoints while retaining its primary URL and transport.
+  - Serialized this metadata as `additionalInterfaces` for wire compatibility and preserved it through AgentCard round trips.
+- Added `examples/transport_production.py` with provider-free configuration, capability, health, and metric inspection.
+
+### Changed
+
+- `Agent`, `AgentClient`, and `Registry` now accept `transport_config=` when constructing transports by name; directly supplied transport objects retain ownership of their existing configuration.
+- `ClientRequestSpec` now declares operation idempotency explicitly. Retries remain disabled by default and run only when the request specification, method, and typed failure all permit a safe retry.
+- HTTP, SSE JSON-RPC, WebSocket, gRPC, and RuntimeTransport now enforce the same serialized payload and concurrency contract, so in-process tests exercise the same resource boundaries as network deployments.
+- Correlation IDs remain stable across retry attempts, while idempotency keys suppress concurrent duplicate execution and replay completed responses within the configured process-local cache window.
+- Expanded the Transport, Agent, Client, Registry, and AgentCard documentation with complete signatures, defaults, protocol mappings, operational rationale, custom-transport guidance, and production examples. The documentation landing-page IDE now includes gRPC and production transport configuration with incremental line editing.
 
 ### Fixed
 
 - Fixed SSE task streams so final nested LLM events no longer close the stream before the final task-status update.
-- Fixed gRPC shutdown so loop-local cached channels are closed and removed correctly.
+- Fixed concurrent duplicate idempotent requests so they await one in-flight operation instead of executing the same handler more than once.
+- Fixed HTTP health probes so `/healthz` and `/readyz` remain available when application authentication is enabled.
+- Fixed transport shutdown across background-thread and caller event loops by closing pooled clients and channels on the event loop that owns them.
+- Fixed gRPC shutdown so loop-local cached channels are closed and removed correctly, including repeated `start()` and `stop()` calls.
 
 ## [0.6.4] - 2026-07-03
 

--- a/docs/content/changelog.md
+++ b/docs/content/changelog.md
@@ -40,6 +40,9 @@ uv add --upgrade protolink
 
 - Added `GRPCTransport`, the `"grpc"` factory registration, gRPC transport conformance coverage, and `examples/grpc_agent.py` for provider-free request/response and streaming usage.
 - Added the top-level `TLSConfig` API with native TLS and optional mutual TLS for HTTP, SSE JSON-RPC, WebSocket, and gRPC transports; secure URL schemes; high-level `Agent`, `AgentClient`, and `Registry` propagation; certificate-backed integration coverage; and `examples/tls_agent.py`.
+- Added one top-level `TransportConfig` API for payload/concurrency limits, explicit idempotent retries, keepalive, graceful shutdown, response deduplication, and local metrics across every transport. `TransportCapabilities` and the public `TransportRequestContext` extension type are available from `protolink.transport`.
+- Added typed transport errors, correlation and idempotency propagation, loop-owned pooled-resource cleanup, idempotent transport lifecycle methods, `/healthz` and `/readyz`, WebSocket ping/pong configuration, and standard gRPC health/reflection services.
+- Added optional `AgentCard.interfaces` metadata for agents exposed through multiple transport endpoints, plus `examples/transport_production.py`.
 
 ### Fixed
 

--- a/docs/content/client.md
+++ b/docs/content/client.md
@@ -8,6 +8,8 @@ The **Client** layer in Protolink provides a high-level interface for agent-to-a
 
 The `AgentClient` is the primary entry point for programmatic agent interactions. It wraps a transport and provides a unified interface for communicating with Protolink agents.
 
+The distinction is useful because application code should think in Agent operations such as “send this task” or “cancel that task,” not in HTTP headers, WebSocket frames, or gRPC metadata. `AgentClient` chooses the operation contract and parses the result; the selected transport only maps that contract onto its wire protocol. Changing from HTTP to gRPC therefore does not require rewriting task-level client code.
+
 Pass `transport_config=` when constructing by transport name to share the same production limits, retry policy, keepalive, shutdown, idempotency, and metrics behavior used by `Agent` and `Registry`. The read-only `client.transport` property exposes health and metric snapshots when an application needs them.
 
 ```python
@@ -111,6 +113,10 @@ AgentClient(
 | `transport_config` | `TransportConfig ⎪ None` | Limits, retry policy, keepalive, shutdown, idempotency cache, and local metrics configuration for a factory-created transport. |
 
 `tls` and `transport_config` are applied when `transport` is a string alias. When you pass an existing `Transport` instance, configure that instance directly; its existing `config` remains authoritative.
+
+Use a string alias when ProtoLink should create and own the transport for you. Use an existing transport object when the application needs protocol-specific constructor options or wants to share that exact instance. In both cases, `AgentClient` exposes the resolved object through `client.transport`; there is no second hidden transport.
+
+You can omit `transport_config` for local use and simple deployments. The default already bounds payloads and concurrency, records metrics, and performs no automatic retries. Supply it when your service has explicit capacity or failure-recovery requirements.
 
 **Examples:**
 
@@ -406,6 +412,10 @@ for event in client.sync.send_task_streaming("http://localhost:8010", task):
 
 `ClientRequestSpec` defines the contract for an API endpoint in a transport-agnostic way.
 
+It is the small description that sits between the high-level client and the wire transport. For example, “send a task” is a `POST` operation with a body and a `Task` response parser. HTTP turns that description into a route request, while WebSocket and gRPC place the same method and path in their envelopes. The client behavior stays identical because the specification describes the operation rather than the protocol.
+
+Normal users rarely need to create request specs; the built-in Agent and Registry clients provide them. They become relevant when adding a new endpoint or implementing a custom client operation. At that point, `idempotent` deserves particular care because it authorizes the retry and duplicate-replay machinery.
+
 ```python
 @dataclass(frozen=True)
 class ClientRequestSpec:
@@ -434,6 +444,8 @@ class ClientRequestSpec:
 
 `idempotent=True` is an application-level safety promise, not an inference made from `POST` or a URL. Custom request specs should enable it only when repeating the operation with the same payload and idempotency key cannot apply the effect twice.
 
+The `channel` field matters only to transports that multiplex several logical operations. Control requests such as cancellation use a separate channel so they are not forced to wait behind the long-running task they are intended to stop. Request/response transports may ignore the distinction while preserving the same client contract.
+
 ### Built-in Request Specs
 
 | Spec | Path | Method | Channel | Idempotent | Description |
@@ -451,8 +463,9 @@ class ClientRequestSpec:
 
 When you call a method like `send_task()`:
 
-1. The client selects the appropriate `ClientRequestSpec` (e.g., `TASK_REQUEST`)
-2. Passes the spec and data to `transport.send()`
-3. The transport uses the spec to construct the wire request
+1. The client selects the appropriate `ClientRequestSpec` (for example, `TASK_REQUEST`).
+2. It passes the specification and task data to `transport.send()`.
+3. The transport creates correlation and idempotency metadata, applies limits, and constructs the protocol-specific request.
+4. The decoded response passes through `response_parser`, so the caller receives a `Task`, `AgentCard`, or another domain model rather than a raw wire dictionary.
 
 If the spec is idempotent and the configured retry policy permits its method, the transport preserves one request ID and idempotency key across attempts. This pattern allows new endpoints without modifying transport implementations while keeping retry safety explicit at the operation boundary.

--- a/docs/content/client.md
+++ b/docs/content/client.md
@@ -10,17 +10,18 @@ The `AgentClient` is the primary entry point for programmatic agent interactions
 
 The distinction is useful because application code should think in Agent operations such as “send this task” or “cancel that task,” not in HTTP headers, WebSocket frames, or gRPC metadata. `AgentClient` chooses the operation contract and parses the result; the selected transport only maps that contract onto its wire protocol. Changing from HTTP to gRPC therefore does not require rewriting task-level client code.
 
-Pass `transport_config=` when the client constructs a transport by name. It uses the same production configuration object accepted by concrete Agent transports and `Registry`. The read-only `client.transport` property exposes health and metric snapshots when an application needs them.
+AgentClient follows the same progressive-control rule as Agent and Registry: a transport name creates a default client quickly, while a concrete transport carries TLS, limits, retries, keepalive, and protocol-specific behavior. The read-only `client.transport` property exposes the resolved transport for health and metric inspection.
 
 ```python
 from protolink import RetryPolicy, TransportConfig
 from protolink.client import AgentClient
+from protolink.transport import GRPCTransport
 
-client = AgentClient(
-    transport="grpc",
+transport = GRPCTransport(
     url="grpc://127.0.0.1:0",
-    transport_config=TransportConfig(retry=RetryPolicy(max_attempts=3)),
+    config=TransportConfig(retry=RetryPolicy(max_attempts=3)),
 )
+client = AgentClient(transport)
 print(client.transport.metrics)
 ```
 
@@ -98,9 +99,6 @@ AgentClient(
     transport: Transport | TransportType,
     url: str | None = None,
     timeout: int = 300,
-    *,
-    tls: TLSConfig | None = None,
-    transport_config: TransportConfig | None = None,
 )
 ```
 
@@ -109,24 +107,24 @@ AgentClient(
 | `transport` | `Transport ⎪ str` | A Transport instance or type string (`"http"`, `"websocket"`, etc.) |
 | `url` | `str ⎪ None` | Base URL when using a transport type string |
 | `timeout` | `int` | Timeout in seconds for the request (default: 300) |
-| `tls` | `TLSConfig ⎪ None` | Optional CA trust and client certificate identity for HTTPS, WSS, or secure gRPC calls. |
-| `transport_config` | `TransportConfig ⎪ None` | Limits, retry policy, keepalive, shutdown, idempotency cache, and local metrics configuration for a factory-created transport. |
 
-`tls` and `transport_config` are applied when `transport` is a string alias. When you pass an existing `Transport` instance, configure that instance directly; its existing `config` remains authoritative.
-
-Use a string alias when ProtoLink should create and own the transport for you. Use an existing transport object when the application needs protocol-specific constructor options or wants to share that exact instance. In both cases, `AgentClient` exposes the resolved object through `client.transport`; there is no second hidden transport.
-
-You can omit `transport_config` for local use and simple deployments. The default already bounds payloads and concurrency, records metrics, and performs no automatic retries. Supply it when your service has explicit capacity or failure-recovery requirements.
+Use a string alias when ProtoLink should create a client transport with defaults. Use an existing transport object when the application needs TLS, production limits, retries, protocol-specific constructor options, or ownership of that exact instance. AgentClient never copies settings onto the transport and never creates a second hidden transport.
 
 **Examples:**
 
 ```python
-# Using transport type string
+# Simple: construct by transport name
 client = AgentClient(transport="http", url="http://localhost:8000", timeout=120)
 
-# Using an existing transport instance
+# Advanced: configure the transport first
+from protolink import TLSConfig, TransportConfig
 from protolink.transport import HTTPTransport
-transport = HTTPTransport(url="http://localhost:8000")
+
+transport = HTTPTransport(
+    url="https://agent.internal:8443",
+    tls=TLSConfig(cafile="certs/ca.pem"),
+    config=TransportConfig(shutdown_timeout=10),
+)
 client = AgentClient(transport=transport)
 ```
 

--- a/docs/content/client.md
+++ b/docs/content/client.md
@@ -10,7 +10,7 @@ The `AgentClient` is the primary entry point for programmatic agent interactions
 
 The distinction is useful because application code should think in Agent operations such as “send this task” or “cancel that task,” not in HTTP headers, WebSocket frames, or gRPC metadata. `AgentClient` chooses the operation contract and parses the result; the selected transport only maps that contract onto its wire protocol. Changing from HTTP to gRPC therefore does not require rewriting task-level client code.
 
-Pass `transport_config=` when constructing by transport name to share the same production limits, retry policy, keepalive, shutdown, idempotency, and metrics behavior used by `Agent` and `Registry`. The read-only `client.transport` property exposes health and metric snapshots when an application needs them.
+Pass `transport_config=` when the client constructs a transport by name. It uses the same production configuration object accepted by concrete Agent transports and `Registry`. The read-only `client.transport` property exposes health and metric snapshots when an application needs them.
 
 ```python
 from protolink import RetryPolicy, TransportConfig

--- a/docs/content/client.md
+++ b/docs/content/client.md
@@ -8,6 +8,20 @@ The **Client** layer in Protolink provides a high-level interface for agent-to-a
 
 The `AgentClient` is the primary entry point for programmatic agent interactions. It wraps a transport and provides a unified interface for communicating with Protolink agents.
 
+Pass `transport_config=` when constructing by transport name to share the same production limits, retry policy, keepalive, shutdown, idempotency, and metrics behavior used by `Agent` and `Registry`. The read-only `client.transport` property exposes health and metric snapshots when an application needs them.
+
+```python
+from protolink import RetryPolicy, TransportConfig
+from protolink.client import AgentClient
+
+client = AgentClient(
+    transport="grpc",
+    url="grpc://127.0.0.1:0",
+    transport_config=TransportConfig(retry=RetryPolicy(max_attempts=3)),
+)
+print(client.transport.metrics)
+```
+
 <ApiSurface
   eyebrow="Client module"
   title="AgentClient"
@@ -84,6 +98,7 @@ AgentClient(
     timeout: int = 300,
     *,
     tls: TLSConfig | None = None,
+    transport_config: TransportConfig | None = None,
 )
 ```
 
@@ -93,6 +108,9 @@ AgentClient(
 | `url` | `str ⎪ None` | Base URL when using a transport type string |
 | `timeout` | `int` | Timeout in seconds for the request (default: 300) |
 | `tls` | `TLSConfig ⎪ None` | Optional CA trust and client certificate identity for HTTPS, WSS, or secure gRPC calls. |
+| `transport_config` | `TransportConfig ⎪ None` | Limits, retry policy, keepalive, shutdown, idempotency cache, and local metrics configuration for a factory-created transport. |
+
+`tls` and `transport_config` are applied when `transport` is a string alias. When you pass an existing `Transport` instance, configure that instance directly; its existing `config` remains authoritative.
 
 **Examples:**
 
@@ -105,6 +123,20 @@ from protolink.transport import HTTPTransport
 transport = HTTPTransport(url="http://localhost:8000")
 client = AgentClient(transport=transport)
 ```
+
+### Transport Inspection
+
+The read-only `transport` property exposes the concrete transport used by the client. This is the supported path for health, readiness, capability, and metric inspection:
+
+```python
+snapshot = client.transport.metrics
+print(snapshot.requests_succeeded, snapshot.retries)
+
+health = client.transport.health()
+print(health["status"], health["ready"])
+```
+
+See the [Shared Transport API Reference](./transport.md#shared-transport-api-reference) for every configuration field, snapshot counter, exception type, and lifecycle probe.
 
 ---
 
@@ -377,26 +409,43 @@ for event in client.sync.send_task_streaming("http://localhost:8010", task):
 ```python
 @dataclass(frozen=True)
 class ClientRequestSpec:
-    name: str                    # Human-readable name (e.g., "send_task")
-    path: str                    # URL path (e.g., "/tasks/")
-    method: HttpMethod           # HTTP method (e.g., "POST")
-    response_parser: Callable    # Function to parse response data
-    request_source: str          # Where to put request data ("body", "query", etc.)
-    channel: str = "default"     # Multiplexed transport channel
+    name: str
+    path: str
+    method: HttpMethod
+    response_parser: Callable[[Any], Any] | None = None
+    request_source: RequestSourceType = "body"
+    content_type: ContentType | None = None
+    accept: ContentType | None = None
+    channel: str = "default"
+    idempotent: bool = False
 ```
+
+| Field | Default | Transport behavior |
+|------|---------|--------------------|
+| `name` | Required | Stable operation name used by request contexts, metrics, and diagnostics. |
+| `path` | Required | Protocol-neutral endpoint path. HTTP-based transports use it directly; multiplexed transports carry it in the request envelope. |
+| `method` | Required | Logical HTTP method used by HTTP routing and retry-method filtering. |
+| `response_parser` | `None` | Optional callable that converts the decoded response into a model such as `Task` or `AgentCard`. |
+| `request_source` | `"body"` | Selects body, query, path, or no request data according to `RequestSourceType`. |
+| `content_type` | `None` | Optional outbound media type override. The transport default is used when omitted. |
+| `accept` | `None` | Optional accepted response media type. The transport default is used when omitted. |
+| `channel` | `"default"` | Logical multiplexing channel. Control operations use `"control"` so persistent transports can isolate them from stream traffic. |
+| `idempotent` | `False` | Explicit declaration that the logical operation can be retried and replayed under one idempotency key. Retries never run unless this is `True`. |
+
+`idempotent=True` is an application-level safety promise, not an inference made from `POST` or a URL. Custom request specs should enable it only when repeating the operation with the same payload and idempotency key cannot apply the effect twice.
 
 ### Built-in Request Specs
 
-| Spec | Path | Method | Description |
-|------|------|--------|-------------|
-| `TASK_REQUEST` | `/tasks/` | POST | Send a task to an agent |
-| `TASK_CANCEL_REQUEST` | `/tasks/cancel` | POST | Cancel an active task over a control channel |
-| `COMPACT_HISTORY_REQUEST` | `/llm/history/compact` | POST | Compact the target agent's LLM history over a control channel |
-| `DESCRIBE_STATE_REQUEST` | `/state/describe` | POST | Inspect target agent state over a control channel |
-| `RESET_STATE_REQUEST` | `/state/reset` | POST | Reset target agent state over a control channel |
-| `COMPACT_STATE_REQUEST` | `/state/compact` | POST | Compact target agent conversation state over a control channel |
-| `AGENT_CARD_REQUEST` | `/.well-known/agent.json` | GET | Retrieve agent metadata |
-| `TASK_STREAM_REQUEST` | `/tasks/stream` | POST | Send task with streaming |
+| Spec | Path | Method | Channel | Idempotent | Description |
+|------|------|--------|---------|------------|-------------|
+| `TASK_REQUEST` | `/tasks/` | POST | default | Yes | Send a task to an agent. The task ID and idempotency key prevent duplicate execution. |
+| `TASK_CANCEL_REQUEST` | `/tasks/cancel` | POST | control | Yes | Cancel an active task. Repeating cancellation has the same terminal effect. |
+| `COMPACT_HISTORY_REQUEST` | `/llm/history/compact` | POST | control | No | Compact the target agent's LLM history. |
+| `DESCRIBE_STATE_REQUEST` | `/state/describe` | POST | control | Yes | Inspect target agent state without mutating it. |
+| `RESET_STATE_REQUEST` | `/state/reset` | POST | control | No | Reset target agent state. |
+| `COMPACT_STATE_REQUEST` | `/state/compact` | POST | control | No | Compact target agent conversation state. |
+| `AGENT_CARD_REQUEST` | `/.well-known/agent.json` | GET | default | Yes | Retrieve agent metadata. |
+| `TASK_STREAM_REQUEST` | `/tasks/stream` | POST | default | No | Send a task and receive a live event stream. Streams are not replayed by the retry layer. |
 
 ### How It Works
 
@@ -406,4 +455,4 @@ When you call a method like `send_task()`:
 2. Passes the spec and data to `transport.send()`
 3. The transport uses the spec to construct the wire request
 
-This pattern allows new endpoints without modifying transport implementations.
+If the spec is idempotent and the configured retry policy permits its method, the transport preserves one request ID and idempotency key across attempts. This pattern allows new endpoints without modifying transport implementations while keeping retry safety explicit at the operation boundary.

--- a/docs/content/concept.md
+++ b/docs/content/concept.md
@@ -29,6 +29,89 @@ Each layer has a **single responsibility** and a clear **dependency direction**.
 
 ---
 
+## API Design: Progressive Control
+
+ProtoLink's API is designed to be **simple at the beginning without becoming restrictive later**. A user should be able to prototype an Agent without first learning transport internals, but production users should still be able to configure every network and runtime boundary explicitly.
+
+This creates two levels of control through one API.
+
+### Simple path: choose a transport
+
+Pass a registered transport name when the defaults are sufficient:
+
+```python
+from protolink import Agent, AgentCard
+
+card = AgentCard(
+    name="assistant",
+    description="General-purpose assistant",
+    url="http://127.0.0.1:8000",
+)
+
+agent = Agent(card=card, transport="http")
+```
+
+ProtoLink resolves the string through its transport factory, creates an `HTTPTransport` from `card.url`, applies bounded default limits, enables local metrics, and leaves retries disabled. The shortcut removes setup code; it does not select a reduced or separate runtime.
+
+This path is intended for prototypes, examples, tests, and deployments that accept the built-in operational defaults.
+
+### Advanced path: configure the boundary
+
+When the transport needs TLS, mutual TLS, custom resource limits, retries, keepalive settings, or protocol-specific options, construct it directly:
+
+```python
+from protolink import Agent, AgentCard, RetryPolicy, TLSConfig, TransportConfig, TransportLimits
+from protolink.transport import HTTPTransport
+
+card = AgentCard(
+    name="assistant",
+    description="Production assistant",
+    url="https://agent.internal:8443",
+)
+transport = HTTPTransport(
+    url=card.url,
+    tls=TLSConfig(
+        certfile="certs/agent.pem",
+        keyfile="certs/agent-key.pem",
+        cafile="certs/ca.pem",
+    ),
+    config=TransportConfig(
+        limits=TransportLimits(max_concurrent_requests=200),
+        retry=RetryPolicy(max_attempts=3),
+    ),
+)
+
+agent = Agent(card=card, transport=transport)
+```
+
+The Agent receives the same `Transport` abstraction in both examples. The only difference is who constructs it: ProtoLink owns construction in the simple path; the application owns construction in the advanced path.
+
+### Why advanced settings live on Transport
+
+Putting every infrastructure option on `Agent` would make the common constructor grow whenever HTTP, WebSocket, gRPC, TLS, or resilience gained a feature. It would also blur ownership: TLS certificates, connection pools, message limits, retry timing, and keepalive behavior are properties of the communication boundary, not of Agent reasoning or task execution.
+
+Keeping these settings on Transport provides several concrete benefits:
+
+- **Clear ownership**: the object opening sockets also owns certificates, pools, limits, retries, and shutdown behavior.
+- **Independent boundaries**: an Agent transport and its Registry transport can use different trust roots, identities, capacities, and retry policies.
+- **Stable Agent API**: adding a gRPC channel option or HTTP backend option does not expand the Agent constructor.
+- **Protocol substitution**: application logic continues to depend on `Transport`, not on protocol-specific settings promoted into Agent.
+- **Reliable serialization**: `Agent.to_dict()` and YAML preserve advanced settings inside each serialized transport block.
+
+| Concern | Owning API | Reason |
+|---------|------------|--------|
+| Identity, tools, LLM, state, policy, task lifecycle | `Agent` | Describes what the autonomous runtime is and does. |
+| Application authentication and authorization | `Agent` / `Authenticator` | Describes who may invoke Agent capabilities. |
+| TLS certificates and trust | Concrete `Transport` | Protects and identifies the network connection. |
+| Payload limits, retries, keepalive, connection pools | `TransportConfig` on a concrete `Transport` | Controls communication resources and failure behavior. |
+| Registry TLS and capacity policy | Registry transport / `RegistryClient` | The Registry is a separate service boundary with independent deployment requirements. |
+
+This is **progressive control**, not a beginner API and an unrelated expert API. Users can begin with a string, move to a configured object when requirements grow, and keep the surrounding Agent code unchanged.
+
+See [Agents](agent.md#simple-and-advanced-transports) for the constructor-level API and [Transport](transport.md#production-configuration) for every production setting.
+
+---
+
 ## Agent
 
 The **Agent** is the central abstraction in Protolink.  
@@ -55,7 +138,7 @@ The agent **does not perform networking** and **does not implement protocols**.
 - Open sockets  
 - Handle HTTP requests  
 - Serialize messages  
-- Know about protocols (HTTP, WS, local, etc.)  
+- Implement protocol behavior or own protocol-specific configuration
 
 This is **intentional and enforced by design**.
 
@@ -124,7 +207,7 @@ It encapsulates:
 - Reusable across agents  
 - Shared by client and server  
 
-> The transport is **never accessed directly by the agent**.
+> Agent business logic never calls protocol primitives directly. The Agent facade composes its client and server around the selected transport.
 
 ---
 
@@ -151,9 +234,9 @@ client/server layer. Protocol details stay below that boundary.
 
 **Key points:**
 
-- The agent owns the client and server  
-- The client and server own the transport  
-- The agent never calls transport methods directly  
+- The Agent composes its client and server
+- The client and server use the same configured transport abstraction
+- Agent business logic never calls protocol methods directly
 
 This guarantees:
 

--- a/docs/content/concept.md
+++ b/docs/content/concept.md
@@ -33,7 +33,7 @@ Each layer has a **single responsibility** and a clear **dependency direction**.
 
 ProtoLink's API is designed to be **simple at the beginning without becoming restrictive later**. A user should be able to prototype an Agent without first learning transport internals, but production users should still be able to configure every network and runtime boundary explicitly.
 
-This creates two levels of control through one API.
+This creates two levels of control through one consistent rule. `Agent`, `AgentClient`, and `Registry` all accept either a registered transport name or a concrete `Transport` instance.
 
 ### Simple path: choose a transport
 
@@ -86,6 +86,31 @@ agent = Agent(card=card, transport=transport)
 
 The Agent receives the same `Transport` abstraction in both examples. The only difference is who constructs it: ProtoLink owns construction in the simple path; the application owns construction in the advanced path.
 
+AgentClient and Registry follow the same progression:
+
+```python
+from protolink import TLSConfig
+from protolink.client import AgentClient
+from protolink.discovery import Registry
+from protolink.transport import HTTPTransport
+
+# Simple facades create default transports.
+client = AgentClient("http", url="http://127.0.0.1:8001")
+registry = Registry("http", url="http://127.0.0.1:9000")
+
+# Advanced facades receive independently configured transport objects.
+client_tls = TLSConfig(cafile="certs/ca.pem")
+registry_tls = TLSConfig(
+    certfile="certs/registry.pem",
+    keyfile="certs/registry-key.pem",
+    cafile="certs/ca.pem",
+)
+client = AgentClient(HTTPTransport("https://agent.internal:8443", tls=client_tls))
+registry = Registry(HTTPTransport("https://registry.internal:9000", tls=registry_tls))
+```
+
+Each service boundary should receive its own transport instance. Sharing configuration values is safe, but sharing a live transport object between unrelated Agent, client, and Registry lifecycles would also share pools, metrics, idempotency caches, and shutdown ownership.
+
 ### Why advanced settings live on Transport
 
 Putting every infrastructure option on `Agent` would make the common constructor grow whenever HTTP, WebSocket, gRPC, TLS, or resilience gained a feature. It would also blur ownership: TLS certificates, connection pools, message limits, retry timing, and keepalive behavior are properties of the communication boundary, not of Agent reasoning or task execution.
@@ -94,7 +119,7 @@ Keeping these settings on Transport provides several concrete benefits:
 
 - **Clear ownership**: the object opening sockets also owns certificates, pools, limits, retries, and shutdown behavior.
 - **Independent boundaries**: an Agent transport and its Registry transport can use different trust roots, identities, capacities, and retry policies.
-- **Stable Agent API**: adding a gRPC channel option or HTTP backend option does not expand the Agent constructor.
+- **Stable facade APIs**: adding a gRPC channel option or HTTP backend option does not expand Agent, AgentClient, or Registry constructors.
 - **Protocol substitution**: application logic continues to depend on `Transport`, not on protocol-specific settings promoted into Agent.
 - **Reliable serialization**: `Agent.to_dict()` and YAML preserve advanced settings inside each serialized transport block.
 
@@ -106,7 +131,7 @@ Keeping these settings on Transport provides several concrete benefits:
 | Payload limits, retries, keepalive, connection pools | `TransportConfig` on a concrete `Transport` | Controls communication resources and failure behavior. |
 | Registry TLS and capacity policy | Registry transport / `RegistryClient` | The Registry is a separate service boundary with independent deployment requirements. |
 
-This is **progressive control**, not a beginner API and an unrelated expert API. Users can begin with a string, move to a configured object when requirements grow, and keep the surrounding Agent code unchanged.
+This is **progressive control**, not a beginner API and an unrelated expert API. Users can begin with a string, move to a configured object when requirements grow, and keep the surrounding Agent, client, and Registry code unchanged.
 
 See [Agents](agent.md#simple-and-advanced-transports) for the constructor-level API and [Transport](transport.md#production-configuration) for every production setting.
 

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -44,6 +44,14 @@ ProtoLink implements and extends [Google's Agent-to-Agent (A2A)](https://a2a-pro
 
 The framework emphasizes **minimal boilerplate**, **explicit control**, and **production-readiness**, making it suitable for both research and real-world systems.
 
+:::tip[Simple API, progressive control]
+
+ProtoLink keeps the common path intentionally small: `Agent(card=card, transport="http")` is enough to start prototyping with safe transport defaults. When a deployment needs TLS, limits, retries, or protocol-specific behavior, construct the transport explicitly and pass the completed object to the same Agent API. This preserves fast iteration without hiding or flattening advanced infrastructure control.
+
+Read the [API design philosophy](concept.md#api-design-progressive-control) or jump to the [transport configuration guide](transport.md#production-configuration).
+
+:::
+
 ## Find Your Path
 
 <ProjectMap />

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -46,7 +46,7 @@ The framework emphasizes **minimal boilerplate**, **explicit control**, and **pr
 
 :::tip[Simple API, progressive control]
 
-ProtoLink keeps the common path intentionally small: `Agent(card=card, transport="http")` is enough to start prototyping with safe transport defaults. When a deployment needs TLS, limits, retries, or protocol-specific behavior, construct the transport explicitly and pass the completed object to the same Agent API. This preserves fast iteration without hiding or flattening advanced infrastructure control.
+ProtoLink keeps the common path intentionally small: `Agent(card=card, transport="http")` is enough to start prototyping with safe transport defaults. When a deployment needs TLS, limits, retries, or protocol-specific behavior, construct the transport explicitly and pass the completed object to `Agent`, `AgentClient`, or `Registry`. This preserves fast iteration without hiding or flattening advanced infrastructure control.
 
 Read the [API design philosophy](concept.md#api-design-progressive-control) or jump to the [transport configuration guide](transport.md#production-configuration).
 

--- a/docs/content/models.md
+++ b/docs/content/models.md
@@ -73,6 +73,7 @@ class AgentCard:
     security_schemes: dict[str, dict[str, Any]] | None = field(default_factory=dict)
     role: AgentRoleType = "worker"
     tags: list[str] = field(default_factory=list)
+    interfaces: list[AgentInterface] = field(default_factory=list)
 ```
 
 Agent identity and capability declaration. This is the main metadata card that describes an agent's identity, capabilities, and security requirements.
@@ -94,6 +95,22 @@ Agent identity and capability declaration. This is the main metadata card that d
 | `security_schemes` | `dict[SecuritySchemeType, dict[str, Any]] | None` | `{}` | Authentication schemes |
 | `role` | `AgentRoleType` | `"worker"` | Agent role is a protocol-level contract that defines the agent's responsibility in the system topology (Extends A2A spec) |
 | `tags` | `list[str]` | `[]` | List of tags for categorization. These tags can be used for filtering during discovery (Protolink extension to A2A spec) E.g. "finance", "travel", "math" etc. (Extends A2A spec) |
+| `interfaces` | `list[AgentInterface]` | `[]` | Additional URLs and transports for the same agent identity. Serialized as `additionalInterfaces`; the card's `url` and `transport` remain primary. |
+
+Use additional interfaces only when one agent is genuinely reachable through multiple transports:
+
+```python
+from protolink import AgentCard, AgentInterface
+
+card = AgentCard(
+    name="worker",
+    description="Task worker",
+    url="https://worker.example",
+    interfaces=[
+        AgentInterface(url="grpcs://worker.example:9443", transport="grpc"),
+    ],
+)
+```
 
 ### Methods
 

--- a/docs/content/registry.md
+++ b/docs/content/registry.md
@@ -280,6 +280,7 @@ Registry(
     entry_ttl_seconds: float | None = None,
     storage: Storage | None = None,
     tls: TLSConfig | None = None,
+    transport_config: TransportConfig | None = None,
 )
 ```
 
@@ -291,6 +292,11 @@ Registry(
 | `entry_ttl_seconds` | `float | None` | `None` | Optional liveness TTL. Expired entries are pruned before discovery, status, and count/list operations. |
 | `storage` | `Storage | None` | `None` | Optional persistence for serialized registry entries. |
 | `tls` | `TLSConfig | None` | `None` | Optional certificate identity and trust configuration for a secure registry URL. |
+| `transport_config` | `TransportConfig | None` | `None` | Limits, retry policy, keepalive, shutdown, idempotency cache, and metrics configuration for a factory-created registry transport. |
+
+`transport_config` is applied when `transport` is a string alias. If an existing `Transport` object is supplied, configure that object directly. The Registry passes the resolved transport to both `RegistryClient` and `RegistryServer`, so inbound serving and outbound registry calls share one capability, health, and metrics surface.
+
+The built-in registry request specs mark `unregister`, `heartbeat`, and `discover` as idempotent. `register` is intentionally not retried automatically because registration may have application-specific replacement semantics. See [ClientRequestSpec](./client.md#clientrequestspec) and the [retry contract](./transport.md#retrypolicy).
 
 :::info[Single source of truth]
 

--- a/docs/content/registry.md
+++ b/docs/content/registry.md
@@ -279,24 +279,46 @@ Registry(
     *,
     entry_ttl_seconds: float | None = None,
     storage: Storage | None = None,
-    tls: TLSConfig | None = None,
-    transport_config: TransportConfig | None = None,
 )
 ```
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `transport` | `TransportType | Transport` | `"http"` | Transport instance or registered transport string. |
-| `url` | `str | None` | `None` | Registry URL. Required when `transport` is a string. |
+| `transport` | `TransportType ⎪ Transport` | `"http"` | Transport instance or registered transport string. |
+| `url` | `str ⎪ None` | `None` | Registry URL. Required when `transport` is a string. |
 | `verbosity` | `Literal[0, 1, 2]` | `1` | Logging verbosity: `0` = warning, `1` = info, `2` = debug. |
-| `entry_ttl_seconds` | `float | None` | `None` | Optional liveness TTL. Expired entries are pruned before discovery, status, and count/list operations. |
-| `storage` | `Storage | None` | `None` | Optional persistence for serialized registry entries. |
-| `tls` | `TLSConfig | None` | `None` | Optional certificate identity and trust configuration for a secure registry URL. |
-| `transport_config` | `TransportConfig | None` | `None` | Limits, retry policy, keepalive, shutdown, idempotency cache, and metrics configuration for a factory-created registry transport. |
+| `entry_ttl_seconds` | `float ⎪ None` | `None` | Optional liveness TTL. Expired entries are pruned before discovery, status, and count/list operations. |
+| `storage` | `Storage ⎪ None` | `None` | Optional persistence for serialized registry entries. |
 
-`transport_config` is applied when `transport` is a string alias. If an existing `Transport` object is supplied, configure that object directly. The Registry passes the resolved transport to both `RegistryClient` and `RegistryServer`, so inbound serving and outbound registry calls share one capability, health, and metrics surface.
+Registry follows the same construction rule as Agent and AgentClient. A string alias creates a default transport for fast setup; a concrete transport carries TLS, limits, retries, keepalive, and protocol-specific settings. The Registry passes that exact instance to both `RegistryClient` and `RegistryServer`, so inbound serving and outbound registry calls share one capability, health, and metrics surface.
 
-The Registry needs the same protections as an Agent even though its requests are smaller. In a large deployment, many Agents may start or heartbeat at once. Concurrency limits keep that burst bounded, payload limits prevent malformed cards from consuming excessive memory, and health metrics reveal whether discovery traffic is failing or saturating the service.
+```python
+# Simple: defaults are sufficient
+registry = Registry(
+    transport="http",
+    url="http://127.0.0.1:9000",
+)
+
+# Advanced: configure the service boundary explicitly
+from protolink import RetryPolicy, TLSConfig, TransportConfig, TransportLimits
+from protolink.transport import HTTPTransport
+
+transport = HTTPTransport(
+    url="https://registry.internal:9000",
+    tls=TLSConfig(
+        certfile="certs/registry.pem",
+        keyfile="certs/registry-key.pem",
+        cafile="certs/ca.pem",
+    ),
+    config=TransportConfig(
+        limits=TransportLimits(max_concurrent_requests=300),
+        retry=RetryPolicy(max_attempts=3),
+    ),
+)
+registry = Registry(transport=transport)
+```
+
+The Registry needs the same protections as an Agent even though its requests are smaller. In a large deployment, many Agents may start or heartbeat at once. Concurrency limits keep that burst bounded, payload limits prevent malformed cards from consuming excessive memory, and health metrics reveal whether discovery traffic is failing or saturating the service. Keeping those settings on its transport also allows the Registry to use a different certificate identity and capacity policy from every Agent that calls it.
 
 The built-in registry request specs mark `unregister`, `heartbeat`, and `discover` as idempotent. `register` is intentionally not retried automatically because registration may have application-specific replacement semantics. See [ClientRequestSpec](./client.md#clientrequestspec) and the [retry contract](./transport.md#retrypolicy).
 

--- a/docs/content/registry.md
+++ b/docs/content/registry.md
@@ -296,7 +296,11 @@ Registry(
 
 `transport_config` is applied when `transport` is a string alias. If an existing `Transport` object is supplied, configure that object directly. The Registry passes the resolved transport to both `RegistryClient` and `RegistryServer`, so inbound serving and outbound registry calls share one capability, health, and metrics surface.
 
+The Registry needs the same protections as an Agent even though its requests are smaller. In a large deployment, many Agents may start or heartbeat at once. Concurrency limits keep that burst bounded, payload limits prevent malformed cards from consuming excessive memory, and health metrics reveal whether discovery traffic is failing or saturating the service.
+
 The built-in registry request specs mark `unregister`, `heartbeat`, and `discover` as idempotent. `register` is intentionally not retried automatically because registration may have application-specific replacement semantics. See [ClientRequestSpec](./client.md#clientrequestspec) and the [retry contract](./transport.md#retrypolicy).
+
+In simple terms, reading discovery results, refreshing the same heartbeat, or removing an already removed URL has a repeatable outcome. Registration can mean “create,” “replace,” or trigger custom persistence behavior, so ProtoLink does not assume that repeating it is harmless. Applications that provide durable idempotent registration semantics can define an explicit custom request contract.
 
 :::info[Single source of truth]
 

--- a/docs/content/transport.md
+++ b/docs/content/transport.md
@@ -97,7 +97,7 @@ The shared APIs exist to solve four practical production problems:
 
 ## Production configuration
 
-Every transport accepts the same `TransportConfig`. Configure it on the concrete transport passed to an Agent, or pass `transport_config=` to `AgentClient` and `Registry` when those APIs create a transport by name. This keeps operational behavior consistent when an application changes protocols: an 8 MiB request limit means the same thing over HTTP, gRPC, WebSocket, or the in-process runtime.
+Every transport accepts the same `TransportConfig`. Configure it on the concrete transport passed to `Agent`, `AgentClient`, or `Registry`. This keeps operational behavior consistent when an application changes protocols: an 8 MiB request limit means the same thing over HTTP, gRPC, WebSocket, or the in-process runtime.
 
 Most applications can start without creating this object. The defaults bound resources, collect local metrics, and keep retries disabled. Add an explicit configuration when deployment requirements differ from those defaults, such as a known maximum task size, a service concurrency budget, or a retry policy approved for your workload.
 
@@ -134,7 +134,7 @@ The same limits apply to RuntimeTransport, making local tests representative of 
 
 :::tip[Start simple, configure explicitly]
 
-Use `Agent(card=card, transport="grpc")` while prototyping. When deployment needs advanced settings, construct `GRPCTransport(url=card.url, config=transport_config)` and pass that object to Agent. `AgentClient` and `Registry` retain `transport_config=` as factory conveniences because they directly own the transport they create.
+Use string aliases while prototyping: `Agent(card=card, transport="grpc")`, `AgentClient("grpc", url=...)`, or `Registry("grpc", url=...)`. When deployment needs advanced settings, construct `GRPCTransport(url=..., config=transport_config)` and pass that object to the facade. The same rule applies everywhere.
 
 :::
 
@@ -583,12 +583,13 @@ For a client that only calls a secure service, certificate trust is enough:
 ```python
 from protolink import TLSConfig
 from protolink.client import AgentClient
+from protolink.transport import GRPCTransport
 
-client = AgentClient(
-    transport="grpc",
+transport = GRPCTransport(
     url="grpc://127.0.0.1:0",
     tls=TLSConfig(cafile="certs/ca.pem"),
 )
+client = AgentClient(transport)
 result = client.sync.send_task("grpcs://worker.internal:9443", task)
 ```
 
@@ -609,7 +610,7 @@ client_tls = TLSConfig(
 )
 ```
 
-Directly constructed `HTTPTransport`, `SSEJSONRPCTransport`, `WebSocketTransport`, and `GRPCTransport` instances accept `tls=`. `AgentClient` and `Registry` also accept it as a convenience when they create a transport by name. `Agent` keeps transport security out of its constructor: pass a configured transport object instead. `Agent.to_dict()` and `to_yaml()` serialize certificate paths inside the transport block; private-key contents are never embedded.
+Directly constructed `HTTPTransport`, `SSEJSONRPCTransport`, `WebSocketTransport`, and `GRPCTransport` instances accept `tls=`. `Agent`, `AgentClient`, and `Registry` keep transport security out of their constructors: pass a configured transport object instead. `Agent.to_dict()` and `to_yaml()` serialize certificate paths inside the transport block; private-key contents are never embedded.
 
 :::note[TLS termination]
 

--- a/docs/content/transport.md
+++ b/docs/content/transport.md
@@ -97,12 +97,13 @@ The shared APIs exist to solve four practical production problems:
 
 ## Production configuration
 
-Every transport accepts the same `TransportConfig`. Pass it at the high-level `Agent`, `AgentClient`, or `Registry` boundary; ProtoLink forwards it to the selected transport. This keeps operational behavior consistent when an application changes protocols: an 8 MiB request limit means the same thing over HTTP, gRPC, WebSocket, or the in-process runtime.
+Every transport accepts the same `TransportConfig`. Configure it on the concrete transport passed to an Agent, or pass `transport_config=` to `AgentClient` and `Registry` when those APIs create a transport by name. This keeps operational behavior consistent when an application changes protocols: an 8 MiB request limit means the same thing over HTTP, gRPC, WebSocket, or the in-process runtime.
 
 Most applications can start without creating this object. The defaults bound resources, collect local metrics, and keep retries disabled. Add an explicit configuration when deployment requirements differ from those defaults, such as a known maximum task size, a service concurrency budget, or a retry policy approved for your workload.
 
 ```python
 from protolink import Agent, AgentCard, RetryPolicy, TransportConfig, TransportLimits
+from protolink.transport import GRPCTransport
 
 transport_config = TransportConfig(
     limits=TransportLimits(
@@ -118,24 +119,22 @@ transport_config = TransportConfig(
     shutdown_timeout=10,
 )
 
-agent = Agent(
-    card=AgentCard(
-        name="worker",
-        description="Production task worker",
-        url="grpcs://worker.internal:9443",
-    ),
-    transport="grpc",
-    transport_config=transport_config,
+card = AgentCard(
+    name="worker",
+    description="Production task worker",
+    url="grpcs://worker.internal:9443",
 )
+transport = GRPCTransport(url=card.url, config=transport_config)
+agent = Agent(card=card, transport=transport)
 ```
 
 `max_attempts=1` is the default, so upgrading never enables retries implicitly. ProtoLink retries only request specifications explicitly marked idempotent, preserves one correlation ID across attempts, and sends an idempotency key so completed operations can be replayed without executing the handler again. Streams are not automatically retried because resuming a partial event sequence requires application-level checkpoints.
 
 The same limits apply to RuntimeTransport, making local tests representative of deployed serialization boundaries. HTTP uses bounded client/server concurrency, WebSocket uses bounded frame queues and ping/pong keepalive, and gRPC applies message-size, keepalive, and concurrent-RPC options.
 
-:::tip[Configure at the highest boundary]
+:::tip[Start simple, configure explicitly]
 
-If you construct an `Agent`, `AgentClient`, or `Registry` with a transport name such as `"grpc"`, pass `transport_config=` there. If you construct `GRPCTransport`, `HTTPTransport`, or another transport object yourself, pass `config=` to that object instead. An existing transport object keeps ownership of its configuration.
+Use `Agent(card=card, transport="grpc")` while prototyping. When deployment needs advanced settings, construct `GRPCTransport(url=card.url, config=transport_config)` and pass that object to Agent. `AgentClient` and `Registry` retain `transport_config=` as factory conveniences because they directly own the transport they create.
 
 :::
 
@@ -536,10 +535,11 @@ See [`examples/transport_production.py`](https://github.com/nMaroulis/protolink/
 
 TLS is transport security: it encrypts traffic and verifies certificates before ProtoLink sends any task data. It is separate from application authentication. Use `TLSConfig` for HTTPS, secure WebSockets, and secure gRPC; use an `Authenticator` for bearer tokens, API keys, Basic auth, or OAuth. Production services commonly use both.
 
-The high-level API accepts the same configuration everywhere:
+Configure TLS on the network transport that owns the socket and certificate identity:
 
 ```python
 from protolink import Agent, AgentCard, TLSConfig
+from protolink.transport import HTTPTransport
 
 tls = TLSConfig(
     certfile="certs/agent.pem",
@@ -547,15 +547,16 @@ tls = TLSConfig(
     cafile="certs/ca.pem",
 )
 
-agent = Agent(
-    card=AgentCard(
-        name="secure-agent",
-        description="Agent served over HTTPS",
-        url="https://agent.internal:8443",
-    ),
-    transport="http",
+card = AgentCard(
+    name="secure-agent",
+    description="Agent served over HTTPS",
+    url="https://agent.internal:8443",
+)
+transport = HTTPTransport(
+    url=card.url,
     tls=tls,
 )
+agent = Agent(card=card, transport=transport)
 ```
 
 The URL scheme activates encryption. The transport name does not change:
@@ -608,7 +609,7 @@ client_tls = TLSConfig(
 )
 ```
 
-`Agent`, `AgentClient`, and `Registry` accept `tls=` when they create a transport by name. Directly constructed `HTTPTransport`, `SSEJSONRPCTransport`, `WebSocketTransport`, and `GRPCTransport` instances accept the same argument. Certificate paths are serialized by `Agent.to_dict()` and `to_yaml()`; private-key contents are never embedded.
+Directly constructed `HTTPTransport`, `SSEJSONRPCTransport`, `WebSocketTransport`, and `GRPCTransport` instances accept `tls=`. `AgentClient` and `Registry` also accept it as a convenience when they create a transport by name. `Agent` keeps transport security out of its constructor: pass a configured transport object instead. `Agent.to_dict()` and `to_yaml()` serialize certificate paths inside the transport block; private-key contents are never embedded.
 
 :::note[TLS termination]
 

--- a/docs/content/transport.md
+++ b/docs/content/transport.md
@@ -48,6 +48,7 @@ All transports inherit from the base `Transport` class.
     - Registers one generic Protolink gRPC service and routes requests by `ClientRequestSpec` method/path.
     - Carries compact JSON envelopes over gRPC byte messages, so no generated protobuf files are required.
     - Supports gRPC metadata for the same bearer/API-key authentication headers used by HTTP and WebSocket transports.
+    - Registers standard gRPC health checking and server reflection when installed through `protolink[grpc]`.
     - Useful for service meshes, polyglot infrastructure, and teams that want gRPC deadlines and connection pooling while keeping Protolink's transport-neutral agent API.
 
 - **RuntimeTransport**
@@ -67,6 +68,374 @@ Some rough guidelines:
 - Use **GRPCTransport** when your deployment already standardizes on gRPC deadlines, metadata, and connection management.
 
 The rest of this page dives into the API of each transport in more detail.
+
+## Production configuration
+
+Every transport accepts the same `TransportConfig`. Pass it at the high-level `Agent`, `AgentClient`, or `Registry` boundary; ProtoLink forwards it to the selected transport.
+
+```python
+from protolink import Agent, AgentCard, RetryPolicy, TransportConfig, TransportLimits
+
+transport_config = TransportConfig(
+    limits=TransportLimits(
+        max_request_bytes=8 * 1024 * 1024,
+        max_response_bytes=8 * 1024 * 1024,
+        max_event_bytes=1024 * 1024,
+        max_concurrent_requests=200,
+        max_concurrent_streams=50,
+    ),
+    retry=RetryPolicy(max_attempts=3),
+    keepalive_interval=20,
+    keepalive_timeout=10,
+    shutdown_timeout=10,
+)
+
+agent = Agent(
+    card=AgentCard(
+        name="worker",
+        description="Production task worker",
+        url="grpcs://worker.internal:9443",
+    ),
+    transport="grpc",
+    transport_config=transport_config,
+)
+```
+
+`max_attempts=1` is the default, so upgrading never enables retries implicitly. ProtoLink retries only request specifications explicitly marked idempotent, preserves one correlation ID across attempts, and sends an idempotency key so completed operations can be replayed without executing the handler again. Streams are not automatically retried because resuming a partial event sequence requires application-level checkpoints.
+
+The same limits apply to RuntimeTransport, making local tests representative of deployed serialization boundaries. HTTP uses bounded client/server concurrency, WebSocket uses bounded frame queues and ping/pong keepalive, and gRPC applies message-size, keepalive, and concurrent-RPC options.
+
+## Shared Transport API Reference
+
+The shared production API is available from the top-level package for normal application code:
+
+```python
+from protolink import (
+    RetryPolicy,
+    TransportConfig,
+    TransportConnectionError,
+    TransportError,
+    TransportLimitError,
+    TransportLimits,
+    TransportMetricsSnapshot,
+    TransportProtocolError,
+    TransportRemoteError,
+    TransportTimeoutError,
+)
+```
+
+Custom transport implementations can import the base contract and extension types from the transport package:
+
+```python
+from protolink.transport import (
+    Transport,
+    TransportCapabilities,
+    TransportRequestContext,
+)
+```
+
+### `TransportConfig`
+
+`TransportConfig` is the single configuration object accepted by every built-in transport. It is immutable and safe to share between an `Agent`, its client, and a `Registry`.
+
+```python
+TransportConfig(
+    limits: TransportLimits = TransportLimits(),
+    retry: RetryPolicy = RetryPolicy(),
+    keepalive_interval: float | None = 20.0,
+    keepalive_timeout: float = 20.0,
+    shutdown_timeout: float = 5.0,
+    idempotency_ttl: float = 300.0,
+    idempotency_cache_size: int = 1024,
+    collect_metrics: bool = True,
+)
+```
+
+| Field | Default | Applied behavior |
+|-------|---------|------------------|
+| `limits` | `TransportLimits()` | Payload and per-event-loop concurrency bounds. |
+| `retry` | `RetryPolicy()` | Bounded retry policy. The default performs one attempt only. |
+| `keepalive_interval` | `20.0` seconds | WebSocket ping interval, HTTP keep-alive expiry, and gRPC keepalive interval. Set `None` to disable periodic WebSocket/HTTP keepalive; gRPC receives a zero interval. |
+| `keepalive_timeout` | `20.0` seconds | WebSocket pong timeout, Uvicorn keep-alive timeout, and gRPC keepalive timeout. |
+| `shutdown_timeout` | `5.0` seconds | Maximum wait for each loop-owned client connection or channel to close. Also used as WebSocket close timeout. |
+| `idempotency_ttl` | `300.0` seconds | How long a completed idempotent result remains replayable. |
+| `idempotency_cache_size` | `1024` | Maximum completed results retained by each transport instance. Oldest results are evicted first. |
+| `collect_metrics` | `True` | Enables the dependency-free in-process metric recorder. When false, snapshots remain available but stay at zero. |
+
+All timing and cache values must be positive, except `keepalive_interval`, which may be `None`. Invalid configurations raise `ValueError` during construction.
+
+`TransportConfig.to_dict()` returns JSON-safe nested dictionaries. `TransportConfig.from_dict(data)` restores `TransportLimits`, `RetryPolicy`, and the retryable-method `frozenset`. `Agent.to_dict()`, YAML serialization, and `Agent.from_dict()` preserve this configuration under the serialized transport block.
+
+### `TransportLimits`
+
+```python
+TransportLimits(
+    max_request_bytes: int = 16 * 1024 * 1024,
+    max_response_bytes: int = 16 * 1024 * 1024,
+    max_event_bytes: int = 4 * 1024 * 1024,
+    max_concurrent_requests: int = 100,
+    max_concurrent_streams: int = 100,
+)
+```
+
+| Field | Default | Meaning |
+|-------|---------|---------|
+| `max_request_bytes` | `16 MiB` | Maximum serialized request envelope or body. |
+| `max_response_bytes` | `16 MiB` | Maximum serialized unary response. |
+| `max_event_bytes` | `4 MiB` | Maximum serialized event yielded by a stream. |
+| `max_concurrent_requests` | `100` | Per-event-loop unary request capacity. Additional work waits for a slot instead of spawning without a bound. |
+| `max_concurrent_streams` | `100` | Per-event-loop active stream capacity. Additional streams wait for a slot. |
+
+Payload sizes are calculated after ProtoLink recursively normalizes domain objects through its normal serializer. A payload over its byte bound raises `TransportLimitError` before it is sent or yielded. Every limit must be greater than zero. `to_dict()` returns all five integer fields.
+
+Protocol-specific mapping:
+
+| Transport | Request/response limits | Concurrency/backpressure |
+|-----------|-------------------------|--------------------------|
+| HTTP | Checked before outbound send and before server response; `httpx` pools use the request limit. | Uvicorn `limit_concurrency` plus per-loop client request slots. |
+| SSE JSON-RPC | HTTP request limits plus `max_event_bytes` for every SSE result. | HTTP concurrency plus a bounded active-stream semaphore. |
+| WebSocket | `websockets` frame size plus explicit request, response, and event checks. | Bounded frame queues, unary handler slots, and active-stream slots. |
+| gRPC | Mapped to `grpc.max_send_message_length` and `grpc.max_receive_message_length`, with explicit envelope checks. | `maximum_concurrent_rpcs` defaults to `max_concurrent_requests`; streams also use active-stream slots. |
+| Runtime | Applies the same serialized-size checks despite not opening a socket. | Both caller and target transports enforce per-loop request and stream slots. |
+
+### `RetryPolicy`
+
+```python
+RetryPolicy(
+    max_attempts: int = 1,
+    initial_backoff: float = 0.1,
+    max_backoff: float = 2.0,
+    jitter: float = 0.1,
+    retryable_methods: frozenset[str] = frozenset({"DELETE", "GET", "POST", "PUT"}),
+)
+```
+
+| Field | Meaning |
+|-------|---------|
+| `max_attempts` | Total attempts, including the initial request. `1` disables retries. |
+| `initial_backoff` | Base delay before the first retry. |
+| `max_backoff` | Upper bound for exponential backoff. Must be at least `initial_backoff`. |
+| `jitter` | Maximum random delay added to each retry. Set `0` for deterministic tests. |
+| `retryable_methods` | HTTP-style methods eligible for retry after the request spec also declares idempotency. |
+
+A request is retried only when all three conditions are true:
+
+1. `ClientRequestSpec.idempotent` is `True`.
+2. The request method appears in `retryable_methods`.
+3. The raised `TransportError` has `retryable=True`.
+
+The delay before retry number `n` is `min(initial_backoff * 2**(n - 1), max_backoff) + uniform(0, jitter)`. The same request ID and idempotency key are retained across every attempt; only `TransportRequestContext.attempt` increases. Streams are never automatically retried because replaying a partial event sequence requires an application checkpoint.
+
+Built-in task submission, agent-card retrieval, cancellation, state description, registry discovery, registry heartbeat, and registry unregister requests declare idempotency. Mutating state compaction/reset operations and streaming requests do not.
+
+### Correlation and idempotency
+
+`TransportRequestContext` is an immutable request-scoped value:
+
+```python
+TransportRequestContext(
+    request_id: str,
+    idempotency_key: str | None = None,
+    attempt: int = 1,
+)
+```
+
+`next_attempt()` returns a new context with the same IDs and `attempt + 1`. `Transport.new_request_context()` generates the initial context. For idempotent payloads it derives the operation key from `id`, `task_id`, or `agent_url` when available; otherwise it uses the generated request ID.
+
+| Transport | Correlation ID | Idempotency key |
+|-----------|----------------|-----------------|
+| HTTP / SSE | `X-Protolink-Request-ID` header | `Idempotency-Key` header |
+| WebSocket | Envelope `id` | Envelope `idempotency_key` |
+| gRPC | Envelope `id` and `x-protolink-request-id` metadata | Envelope `idempotency_key` and `idempotency-key` metadata |
+| Runtime | In-process `TransportRequestContext` | In-process namespaced operation key |
+
+Server-side keys are namespaced by method and path. The first request owns the operation; concurrent duplicates await its result, and later duplicates replay the completed result until the TTL expires. This cache is process-local. Use a durable application-level idempotency store as well when operations must remain deduplicated across restarts or multiple server replicas.
+
+### `TransportCapabilities`
+
+Every transport declares immutable class-level capabilities. Applications normally inspect `transport.capabilities`; custom transports set the class attribute.
+
+```python
+TransportCapabilities(
+    networked: bool = True,
+    streaming: bool = False,
+    tls: bool = False,
+    bidirectional: bool = False,
+    persistent_connections: bool = False,
+)
+```
+
+| Transport | Networked | Streaming | TLS | Bidirectional | Persistent connections |
+|-----------|-----------|-----------|-----|---------------|------------------------|
+| `HTTPTransport` | Yes | No | Yes | No | Yes |
+| `SSEJSONRPCTransport` | Yes | Yes | Yes | No | Yes |
+| `WebSocketTransport` | Yes | Yes | Yes | Yes | Yes |
+| `GRPCTransport` | Yes | Yes | Yes | No | Yes |
+| `RuntimeTransport` | No | Yes | No | No | No |
+
+`supports_streaming` remains available as the compatibility flag used by `AgentClient` and `AgentServer`; it matches `capabilities.streaming` on all built-in transports.
+
+### `Transport` base class
+
+Application code usually receives a transport from `Agent.transport` or `AgentClient.transport`. The stable inspection surface is:
+
+| Member | Type | Purpose |
+|--------|------|---------|
+| `transport_type` | `ClassVar[str]` | Factory/card identifier such as `"http"`, `"grpc"`, or `"runtime"`. |
+| `supports_streaming` | `ClassVar[bool]` | Compatibility flag used to decide whether `/tasks/stream` is registered. |
+| `capabilities` | `ClassVar[TransportCapabilities]` | Declarative transport behavior. |
+| `config` | `TransportConfig` | Effective shared configuration for this instance. |
+| `url` | `str` | Canonical bind/identity URL. |
+| `metrics` | `TransportMetricsSnapshot` | Immutable snapshot taken at property access time. |
+| `is_running` | `bool` | Whether this instance currently owns a running server endpoint. |
+| `health()` | `dict[str, Any]` | JSON-compatible readiness, capability, and metric payload. |
+| `validate_url()` | `bool` | Whether the configured URL uses a scheme accepted by the transport. |
+| `start()` / `stop()` | `Awaitable[None]` | Idempotent server and pooled-resource lifecycle. |
+| `send(...)` | `Awaitable[Any]` | Low-level unary request primitive used by clients. |
+| `subscribe(agent_url, task)` | `AsyncIterator[Any]` | Low-level streaming primitive; unsupported transports raise `NotImplementedError`. |
+
+#### Custom transport contract
+
+A custom transport subclasses `Transport`, calls `super().__init__(config=config)`, declares its class capabilities, and implements `send`, `setup_routes`, `start`, `stop`, `validate_url`, and `url`. Streaming transports also override `subscribe`.
+
+The base class exposes reusable extension hooks so custom transports can preserve the built-in operational contract:
+
+| Method | Intended use |
+|--------|--------------|
+| `new_request_context(request_spec, data=None)` | Generate stable correlation and optional idempotency metadata. |
+| `payload_size(payload)` | Return the normalized UTF-8 JSON size estimate. |
+| `check_payload_limit(payload, kind, url=None)` | Enforce `kind="request"`, `"response"`, or `"event"`; returns measured bytes. |
+| `request_slot()` | Async context manager for bounded outbound unary work. Pair it with `run_with_retries()`. |
+| `inbound_request_slot()` | Async context manager for bounded inbound unary work and full outcome metrics. |
+| `stream_slot()` | Async context manager for bounded streams and stream outcome metrics. |
+| `run_with_retries(request_spec, context, operation)` | Execute an async operation under retry eligibility, backoff, and request metrics. |
+| `register_loop_resource(key, closer)` | Record an async client/channel closer with the event loop that owns it. |
+| `discard_loop_resource(key)` | Remove a resource that was already invalidated or closed. |
+| `close_loop_resources()` | Close all registered resources on their owning loops under `shutdown_timeout`. |
+| `acquire_idempotent_response(key)` | Claim an operation or await/replay an existing result. Returns `(owns_operation, result)`. |
+| `complete_idempotent_response(key, response)` | Publish and cache a successful or protocol-level response. |
+| `abort_idempotent_response(key, error)` | Release waiting duplicates when execution fails before a response exists. |
+
+These hooks are an extension API for transport authors. Normal agent applications should configure the transport and call `AgentClient`, not manually coordinate slots or idempotency ownership.
+
+#### Internal instance state
+
+The base constructor creates the following private variables. They explain lifecycle behavior but are not a public mutation surface:
+
+| Variable | Role |
+|----------|------|
+| `_metrics` | Thread-safe mutable recorder behind the immutable `metrics` property. |
+| `_request_semaphores` | Per-event-loop unary request semaphores. Separate loops never share asyncio primitives. |
+| `_stream_semaphores` | Per-event-loop active-stream semaphores. |
+| `_resource_lock` | Thread lock protecting loop-owned resource registration. |
+| `_loop_resources` | Resource key to `(owner_loop, async_closer)` mapping used during cross-loop shutdown. |
+| `_idempotency_lock` | Thread lock protecting completed and in-flight operation state. |
+| `_idempotency_cache` | TTL-bound, oldest-first completed response cache. |
+| `_idempotency_inflight` | Shared futures used so concurrent duplicate requests await one owner. |
+| `_transport_running` | Base lifecycle flag used by `is_running` and health reporting. |
+
+Do not replace or mutate these collections from application code. A custom transport should use the public helper methods above.
+
+### `TransportMetricsSnapshot`
+
+`transport.metrics` returns a new immutable snapshot. Reading it does not reset counters.
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `requests_started` | `int` | Unary request executions admitted by this instance. |
+| `requests_succeeded` | `int` | Unary executions completed successfully. |
+| `requests_failed` | `int` | Unary executions ending with an exception or terminal transport failure. |
+| `retries` | `int` | Additional attempts started by `RetryPolicy`. |
+| `streams_started` | `int` | Streams admitted by this instance. |
+| `streams_completed` | `int` | Streams that exited normally. |
+| `streams_failed` | `int` | Streams that exited with an exception or cancellation. |
+| `active_requests` | `int` | Current unary request gauge. |
+| `active_streams` | `int` | Current stream gauge. |
+| `bytes_sent` | `int` | Estimated normalized payload bytes attempted by outbound operations. Retries add bytes again. |
+| `bytes_received` | `int` | Estimated normalized result bytes accepted by outbound operations. |
+| `total_latency_ms` | `float` | Cumulative unary latency, not an average or histogram. |
+
+`snapshot.to_dict()` produces the exact JSON-compatible mapping embedded in health responses. Metrics are process-local operational counters, not a replacement for durable telemetry. Set `collect_metrics=False` when another layer owns all measurement.
+
+### Transport errors
+
+All transport exceptions inherit from `TransportError` and expose the same diagnostic attributes:
+
+```python
+TransportError(
+    message: str,
+    *,
+    url: str | None = None,
+    request_id: str | None = None,
+    retryable: bool = False,
+    status_code: int | str | None = None,
+)
+```
+
+| Error | Compatibility base | Raised for |
+|-------|--------------------|------------|
+| `TransportConnectionError` | `ConnectionError` | Connection establishment, retention, or peer availability failure. |
+| `TransportTimeoutError` | `TimeoutError` | Request or stream deadline expiry. |
+| `TransportProtocolError` | `RuntimeError` | Invalid JSON/envelope shape, mismatched request ID, or incompatible wire response. |
+| `TransportRemoteError` | `RuntimeError` | A reachable peer returns an HTTP/gRPC status or protocol error result. |
+| `TransportLimitError` | `ValueError` | Serialized request, response, or event exceeds its configured byte limit. |
+
+`retryable` describes the failure category only; the request spec and method must still permit retries. `status_code` is an HTTP integer or protocol-native string such as a gRPC status name. `request_id` lets logs and traces correlate the exception with request headers or envelopes.
+
+```python
+try:
+    result = await client.send_task(agent_url, task)
+except TransportError as exc:
+    logger.error(
+        "transport failed",
+        extra={
+            "url": exc.url,
+            "request_id": exc.request_id,
+            "retryable": exc.retryable,
+            "status_code": exc.status_code,
+        },
+    )
+```
+
+### Health and readiness
+
+`transport.health()` returns this transport-neutral shape:
+
+```json
+{
+  "status": "ready",
+  "ready": true,
+  "transport": "grpc",
+  "url": "grpc://127.0.0.1:9001",
+  "capabilities": {
+    "networked": true,
+    "streaming": true,
+    "tls": true,
+    "bidirectional": false,
+    "persistent_connections": true
+  },
+  "metrics": {
+    "requests_started": 12,
+    "requests_succeeded": 12,
+    "requests_failed": 0,
+    "retries": 1,
+    "streams_started": 2,
+    "streams_completed": 2,
+    "streams_failed": 0,
+    "active_requests": 0,
+    "active_streams": 0,
+    "bytes_sent": 4096,
+    "bytes_received": 8192,
+    "total_latency_ms": 184.5
+  }
+}
+```
+
+Agents and registries expose the same payload at `GET /healthz` and `GET /readyz`. These probe endpoints do not require application authentication. `ready` becomes true after the transport server starts and false after it stops.
+
+gRPC additionally exposes `grpc.health.v1.Health` and service discovery through reflection when the packages installed by `protolink[grpc]` are present. Direct `GRPCTransport` construction accepts `enable_health=False` and `enable_reflection=False` to disable either service.
+
+See [`examples/transport_production.py`](https://github.com/nMaroulis/protolink/blob/main/examples/transport_production.py) for a provider-free configuration example.
 
 ## TLS and mutual TLS
 
@@ -220,6 +589,8 @@ The repository includes `tests/test_transport_conformance.py` to keep Runtime, H
 | `POST /state/compact` | Compact persisted conversation state. | No, JSON API |
 | `GET /.well-known/agent.json` | Return the public `AgentCard`. | Yes, JSON document |
 | `GET /status` | Render the agent status page. | Yes, HTML page |
+| `GET /healthz` | Return transport liveness and metrics. | Yes, JSON document |
+| `GET /readyz` | Return transport readiness and metrics. | Yes, JSON document |
 | `GET /chat` | Render the self-contained chat UI or a fallback page. | Yes, HTML page |
 | `POST /chat` | Send a chat message to `Agent.invoke()`. Registered only when the agent has an LLM. | No, JSON API used by the page |
 | `POST /tasks/stream` | Stream task events. Registered only when the transport advertises streaming support. | SSE, WebSocket, gRPC, or runtime stream depending on transport |
@@ -233,6 +604,8 @@ The repository includes `tests/test_transport_conformance.py` to keep Runtime, H
 | `POST /agents/heartbeat` | Refresh agent liveness metadata. | No, JSON API |
 | `GET /agents/` | Discover registered agents. | Yes, JSON document |
 | `GET /status` | Render the registry status page. | Yes, HTML page |
+| `GET /healthz` | Return transport liveness and metrics. | Yes, JSON document |
+| `GET /readyz` | Return transport readiness and metrics. | Yes, JSON document |
 
 ### Transport mapping
 
@@ -481,7 +854,7 @@ The most important public methods on `HTTPTransport` are summarized below.
 
 | Name | Parameters | Returns | Description |
 | ---- | ---------- | ------- | ----------- |
-| `__init__` | `url: str`, `timeout: float = 360.0`, `authenticator: Authenticator ⎪ None = None`, `backend: Literal["starlette", "fastapi"] = "starlette"`, `validate_schema: bool = False`, `credentials: str ⎪ None = None`, `tls: TLSConfig ⎪ None = None`, `log_level: str = "info"`, `access_log: bool = True` | `None` | Configure URL, timeout, authentication, TLS, backend, validation, and Uvicorn logging behavior. |
+| `__init__` | `url: str`, `timeout: float = 360.0`, `authenticator: Authenticator ⎪ None = None`, `backend: Literal["starlette", "fastapi"] = "starlette"`, `validate_schema: bool = False`, `credentials: str ⎪ None = None`, `tls: TLSConfig ⎪ None = None`, `config: TransportConfig ⎪ None = None`, `log_level: str = "info"`, `access_log: bool = True` | `None` | Configure URL, timeout, authentication, TLS, shared production behavior, backend, validation, and Uvicorn logging. |
 | `start` | `self` | `Awaitable[None]` | Start the selected backend and create the internal `httpx.AsyncClient`. `AgentServer` or `RegistryServer` registers endpoint specs before transport startup. |
 | `stop` | `self` | `Awaitable[None]` | Stop the backend server and close the internal HTTP client. Safe to call multiple times. |
 
@@ -491,6 +864,10 @@ The most important public methods on `HTTPTransport` are summarized below.
 | ---- | ---- | ------ | ----------- |
 | `url` | `str` | Read-only | The base URL configured for this transport. |
 | `timeout` | `float` | Read/Write | The request timeout (in seconds) for outgoing requests. This can be changed at runtime to easily adjust timeouts for subsequent requests without restarting the transport. |
+| `config` | `TransportConfig` | Read-only reference | Effective limits, retry, keepalive, shutdown, idempotency, and metric settings. |
+| `capabilities` | `TransportCapabilities` | Class-level | Networked, TLS-capable, persistent, unary-only capability declaration. |
+| `metrics` | `TransportMetricsSnapshot` | Read-only snapshot | Current request, retry, byte, stream, and latency counters. |
+| `is_running` | `bool` | Read-only | Whether the ASGI server is running. |
 
 #### Sending & receiving
 
@@ -504,8 +881,8 @@ The most important public methods on `HTTPTransport` are summarized below.
 | Name | Parameters | Returns | Description |
 | ---- | ---------- | ------- | ----------- |
 | `authenticate` | `credentials: str` | `Awaitable[None]` | Use the configured `Authenticator` to obtain an auth context (for example, exchanging an API key for a bearer token). The resulting context is automatically injected into outgoing HTTP headers. |
-| `_build_headers` | `skill: str ⎪ None = None` | `dict[str, str]` | Internal helper that constructs HTTP headers (including `Authorization` when an auth context is present). Exposed here for completeness; you normally do not need to call it directly. |
 | `validate_url` | `-` | `bool` | Return `True` when the configured URL uses `http://` or `https://`. |
+| `health` | `-` | `dict[str, Any]` | Return readiness, capabilities, URL, and metric snapshot. |
 
 ---
 
@@ -576,7 +953,7 @@ async def main() -> None:
 
 | Method | Parameters | Returns | Description |
 |--------|------------|---------|-------------|
-| `__init__` | `url: str` | `None` | Create an isolated in-memory transport. Bound to a specified runtime URL. |
+| `__init__` | `url: str`, `config: TransportConfig ⎪ None = None` | `None` | Create an isolated in-memory transport with the same limits, retries, idempotency, and metrics contract as network transports. |
 | `start` | `self` | `Awaitable[None]` | Register the allocated `url` actively directly on the class-level registry cache. |
 | `stop` | `self` | `Awaitable[None]` | Detach registry allocations cleaning up in-memory routing bindings. |
 
@@ -586,6 +963,9 @@ async def main() -> None:
 | ---- | ---- | ------ | ----------- |
 | `url` | `str` | Read-only | The unique runtime URL allocated to this transport. |
 | `is_running` | `bool` | Read-only | Whether the transport is currently registered in the global in-memory registry. |
+| `config` | `TransportConfig` | Read-only reference | Effective shared production configuration. |
+| `capabilities` | `TransportCapabilities` | Class-level | In-process, streaming, non-networked capability declaration. |
+| `metrics` | `TransportMetricsSnapshot` | Read-only snapshot | Current request, stream, retry, byte, and latency counters. |
 
 #### Sending
 
@@ -619,9 +999,13 @@ Use it when:
 
 | Name | Parameters | Returns | Description |
 | ---- | ---------- | ------- | ----------- |
-| `__init__` | `url: str`, `timeout: float = 360.0`, `authenticator: Authenticator ⎪ None = None`, `credentials: str ⎪ None = None`, `tls: TLSConfig ⎪ None = None` | `None` | Configure URL, timeout, authentication, credentials, and TLS for `wss://` connections. |
+| `__init__` | `url: str`, `timeout: float = 360.0`, `authenticator: Authenticator ⎪ None = None`, `credentials: str ⎪ None = None`, `tls: TLSConfig ⎪ None = None`, `config: TransportConfig ⎪ None = None` | `None` | Configure URL, timeout, authentication, credentials, TLS, frame/concurrency limits, ping/pong keepalive, retry, shutdown, idempotency, and metrics. |
+| `send` | `request_spec`, `base_url`, `data=None`, `params=None` | `Awaitable[Any]` | Send one correlated JSON envelope over a loop-local persistent connection. Control-channel specs use a separate cached connection. |
 | `subscribe` | `agent_url: str`, `task: Any` | `AsyncIterator[Any]` | Send a `Task` to `/tasks/stream` and receive task event payloads over a single WebSocket connection. |
+| `setup_routes` | `endpoints: list[EndpointSpec]` | `None` | Cache endpoint specs for the server-side frame router. |
 | `start` / `stop` | `self` | `Awaitable[None]` | Start or stop the WebSocket server. |
+| `validate_url` | `-` | `bool` | Accept `ws://` and `wss://` URLs. |
+| `health` | `-` | `dict[str, Any]` | Return shared readiness, capability, and metric data. |
 
 #### Properties
 
@@ -629,6 +1013,9 @@ Use it when:
 | ---- | ---- | ------ | ----------- |
 | `url` | `str` | Read-only | The base URL configured for this transport. |
 | `timeout` | `float` | Read/Write | The timeout (in seconds) for WebSocket receive operations. This can be changed at runtime to adjust response wait times for subsequent requests. |
+| `config` | `TransportConfig` | Read-only reference | Effective limits, retry, ping/pong, shutdown, idempotency, and metric settings. |
+| `capabilities` | `TransportCapabilities` | Class-level | Networked, streaming, TLS-capable, bidirectional, persistent capability declaration. |
+| `metrics` | `TransportMetricsSnapshot` | Read-only snapshot | Current unary and stream counters, bytes, retries, and latency. |
 
 ---
 
@@ -702,11 +1089,15 @@ Authentication uses gRPC metadata keys compatible with the HTTP headers Protolin
 
 | Name | Parameters | Returns | Description |
 | ---- | ---------- | ------- | ----------- |
-| `__init__` | `url: str`, `timeout: float = 360.0`, `authenticator: Authenticator ⎪ None = None`, `credentials: str ⎪ None = None`, `channel_options = None`, `server_options = None`, `compression = None`, `maximum_concurrent_rpcs: int ⎪ None = None`, `graceful_shutdown_timeout: float = 3.0`, `tls: TLSConfig ⎪ None = None` | `None` | Configure the gRPC endpoint, deadlines, auth, TLS/mTLS, grpcio options, compression, and server shutdown grace. |
+| `__init__` | `url: str`, `timeout: float = 360.0`, `authenticator: Authenticator ⎪ None = None`, `credentials: str ⎪ None = None`, `channel_options = None`, `server_options = None`, `compression = None`, `maximum_concurrent_rpcs: int ⎪ None = None`, `graceful_shutdown_timeout: float = 3.0`, `tls: TLSConfig ⎪ None = None`, `config: TransportConfig ⎪ None = None`, `enable_health: bool = True`, `enable_reflection: bool = True` | `None` | Configure deadlines, auth, TLS/mTLS, shared limits/retries/keepalive, grpcio overrides, compression, shutdown grace, standard health, and reflection. Explicit gRPC options override values derived from `config`. |
 | `send` | `request_spec`, `base_url`, `data`, `params` | `Awaitable[Any]` | Send a unary request to the peer's `Invoke` method and parse the response through the request spec. |
 | `subscribe` | `agent_url: str`, `task: Any` | `AsyncIterator[Any]` | Send a task to `Stream` and yield each task event result until the stream is final. |
 | `setup_routes` | `endpoints: list[EndpointSpec]` | `None` | Cache transport-neutral endpoint specs for the generic gRPC router. |
 | `start` / `stop` | `self` | `Awaitable[None]` | Start or stop the `grpc.aio` server and loop-local client channels. |
+| `validate_url` | `-` | `bool` | Accept `grpc://` and `grpcs://` URLs. |
+| `url` / `timeout` | `str` / `float` | URL read-only; timeout read/write | Inspect the server identity URL or adjust future call deadlines. |
+| `config` / `capabilities` / `metrics` | Shared types | Read-only | Inspect effective production settings, declared behavior, and operational counters. |
+| `health` | `-` | `dict[str, Any]` | Return ProtoLink health data; standard gRPC health is exposed separately when enabled. |
 
 ---
 
@@ -751,5 +1142,7 @@ Event results are normalized recursively before the SSE frame is encoded. For ex
 
 | Name | Parameters | Returns | Description |
 | ---- | ---------- | ------- | ----------- |
+| `__init__` | Same as `HTTPTransport`, including `config: TransportConfig ⎪ None = None` | `None` | Configure the inherited HTTP unary path and SSE streaming production behavior. |
 | `subscribe` | `agent_url: str`, `task: Any` | `AsyncIterator[Any]` | POST a task to `/tasks/stream`, parse SSE JSON-RPC envelopes, and yield each `result` payload. |
 | `send` | `request_spec`, `base_url`, `data`, `params` | `Awaitable[Any]` | Inherited from `HTTPTransport` for normal request/response calls. |
+| `config` / `capabilities` / `metrics` | Shared types | Read-only | Inspect effective settings, streaming/TLS capabilities, and unary/stream counters. |

--- a/docs/content/transport.md
+++ b/docs/content/transport.md
@@ -69,9 +69,37 @@ Some rough guidelines:
 
 The rest of this page dives into the API of each transport in more detail.
 
+## How a request moves through a transport
+
+For everyday use, a transport is simply the part of ProtoLink that moves a task from one process to another. The Agent decides **what** work should happen; the transport decides **how** the request and response cross the boundary safely.
+
+One normal unary request follows this path:
+
+1. `AgentClient` selects a `ClientRequestSpec`, which describes the operation without depending on HTTP, WebSocket, gRPC, or another protocol.
+2. The transport creates a request context containing a correlation ID and, for safe repeatable operations, an idempotency key.
+3. ProtoLink serializes the payload and checks its configured byte limit.
+4. The request waits for a concurrency slot. This applies backpressure when the process is already busy instead of starting unlimited work.
+5. The concrete transport sends the request using headers, metadata, or an envelope appropriate for its protocol.
+6. If the connection fails, ProtoLink retries only when the operation, method, and error all say that retrying is safe.
+7. The receiving transport deduplicates idempotent requests, executes the endpoint handler, checks the response size, and returns the result.
+8. Metrics and health state are updated around the operation so applications can inspect what happened.
+
+Streaming requests use the same ideas, but hold a stream slot and check every event independently. ProtoLink does not automatically restart a failed stream because it cannot know which events the consumer already processed.
+
+The shared APIs exist to solve four practical production problems:
+
+| Problem | ProtoLink feature | Why it matters |
+|---------|-------------------|----------------|
+| A large payload or traffic spike exhausts memory | `TransportLimits` and request/stream slots | Work is bounded before one busy peer destabilizes the whole process. |
+| A temporary network failure interrupts a safe operation | `RetryPolicy` plus `ClientRequestSpec.idempotent` | Safe operations can recover without blindly repeating state changes. |
+| A retry arrives after the server already completed the first attempt | Correlation IDs and idempotency keys | The duplicate receives the original result instead of executing the handler twice. |
+| Operators cannot tell whether a service is ready or failing | Typed errors, metrics, and health endpoints | Failures become inspectable and automation can make informed decisions. |
+
 ## Production configuration
 
-Every transport accepts the same `TransportConfig`. Pass it at the high-level `Agent`, `AgentClient`, or `Registry` boundary; ProtoLink forwards it to the selected transport.
+Every transport accepts the same `TransportConfig`. Pass it at the high-level `Agent`, `AgentClient`, or `Registry` boundary; ProtoLink forwards it to the selected transport. This keeps operational behavior consistent when an application changes protocols: an 8 MiB request limit means the same thing over HTTP, gRPC, WebSocket, or the in-process runtime.
+
+Most applications can start without creating this object. The defaults bound resources, collect local metrics, and keep retries disabled. Add an explicit configuration when deployment requirements differ from those defaults, such as a known maximum task size, a service concurrency budget, or a retry policy approved for your workload.
 
 ```python
 from protolink import Agent, AgentCard, RetryPolicy, TransportConfig, TransportLimits
@@ -104,6 +132,12 @@ agent = Agent(
 `max_attempts=1` is the default, so upgrading never enables retries implicitly. ProtoLink retries only request specifications explicitly marked idempotent, preserves one correlation ID across attempts, and sends an idempotency key so completed operations can be replayed without executing the handler again. Streams are not automatically retried because resuming a partial event sequence requires application-level checkpoints.
 
 The same limits apply to RuntimeTransport, making local tests representative of deployed serialization boundaries. HTTP uses bounded client/server concurrency, WebSocket uses bounded frame queues and ping/pong keepalive, and gRPC applies message-size, keepalive, and concurrent-RPC options.
+
+:::tip[Configure at the highest boundary]
+
+If you construct an `Agent`, `AgentClient`, or `Registry` with a transport name such as `"grpc"`, pass `transport_config=` there. If you construct `GRPCTransport`, `HTTPTransport`, or another transport object yourself, pass `config=` to that object instead. An existing transport object keeps ownership of its configuration.
+
+:::
 
 ## Shared Transport API Reference
 
@@ -138,6 +172,15 @@ from protolink.transport import (
 
 `TransportConfig` is the single configuration object accepted by every built-in transport. It is immutable and safe to share between an `Agent`, its client, and a `Registry`.
 
+It is a container for four kinds of operational policy:
+
+- `limits` controls how much work and data one transport instance may accept at once.
+- `retry` controls recovery from temporary failures, but only for explicitly safe operations.
+- Keepalive and shutdown values control the lifecycle of pooled or persistent connections.
+- Idempotency and metrics values control duplicate-response retention and local observability.
+
+Keeping these values together avoids protocol-specific production settings scattered across application code. The object is immutable because changing limits or retry behavior halfway through active requests would make behavior timing-dependent. Create a new transport configuration when settings need to change.
+
 ```python
 TransportConfig(
     limits: TransportLimits = TransportLimits(),
@@ -166,7 +209,16 @@ All timing and cache values must be positive, except `keepalive_interval`, which
 
 `TransportConfig.to_dict()` returns JSON-safe nested dictionaries. `TransportConfig.from_dict(data)` restores `TransportLimits`, `RetryPolicy`, and the retryable-method `frozenset`. `Agent.to_dict()`, YAML serialization, and `Agent.from_dict()` preserve this configuration under the serialized transport block.
 
+The keepalive settings do not change how long an Agent task may run. They only determine how idle or persistent network connections are checked and retained. Similarly, `shutdown_timeout` is a cleanup grace period, not a request deadline.
+
 ### `TransportLimits`
+
+Limits protect the process from accidental overload. They are not authentication or authorization rules: they do not decide who may call an Agent, only how much data and concurrent work the transport will accept.
+
+There are two independent kinds of limit:
+
+- **Byte limits** reject one request, response, or stream event that is too large. This prevents a single payload from consuming an unexpected amount of memory.
+- **Concurrency limits** bound how many operations execute at once. Extra operations wait asynchronously for a slot, which slows producers naturally without blocking the event loop or immediately rejecting ordinary bursts.
 
 ```python
 TransportLimits(
@@ -188,6 +240,8 @@ TransportLimits(
 
 Payload sizes are calculated after ProtoLink recursively normalizes domain objects through its normal serializer. A payload over its byte bound raises `TransportLimitError` before it is sent or yielded. Every limit must be greater than zero. `to_dict()` returns all five integer fields.
 
+Choose byte limits from the largest valid serialized task your application expects, with some headroom for envelope metadata. Choose concurrency limits from measured CPU, memory, downstream-service, and model-provider capacity. Higher values increase parallelism but also increase peak resource use; they do not make an individual request faster.
+
 Protocol-specific mapping:
 
 | Transport | Request/response limits | Concurrency/backpressure |
@@ -199,6 +253,10 @@ Protocol-specific mapping:
 | Runtime | Applies the same serialized-size checks despite not opening a socket. | Both caller and target transports enforce per-loop request and stream slots. |
 
 ### `RetryPolicy`
+
+A retry is useful when the operation is safe but the connection is temporarily unhealthy: for example, a connection reset before the client receives the response. A retry is dangerous when repeating the operation could apply a mutation twice. For that reason, ProtoLink separates **how often retrying is allowed** (`RetryPolicy`) from **whether this operation is safe to repeat** (`ClientRequestSpec.idempotent`).
+
+Retries are disabled by default. Setting `max_attempts=3` means one initial attempt and at most two retries; it does not mean three additional retries. Exponential backoff spaces attempts farther apart so a recovering service is not immediately flooded again. Jitter adds a small random offset so many clients do not retry at exactly the same moment.
 
 ```python
 RetryPolicy(
@@ -228,7 +286,16 @@ The delay before retry number `n` is `min(initial_backoff * 2**(n - 1), max_back
 
 Built-in task submission, agent-card retrieval, cancellation, state description, registry discovery, registry heartbeat, and registry unregister requests declare idempotency. Mutating state compaction/reset operations and streaming requests do not.
 
+The transport retries only typed `TransportError` failures marked `retryable=True`. Application exceptions and protocol errors that indicate invalid data are returned immediately because waiting and trying the same invalid operation again cannot repair them.
+
 ### Correlation and idempotency
+
+Correlation and idempotency solve related but different problems:
+
+- A **request ID** answers “which logical request produced this log, metric, or error?” It stays the same across retry attempts so operators can follow the whole operation.
+- An **idempotency key** answers “has this logical operation already executed?” The server uses it to suppress duplicate execution and replay the completed result.
+
+Consider a task that completes on the server, but the response connection breaks before the client receives it. The client cannot tell whether execution happened, so it retries. The repeated request keeps the same idempotency key; the server returns the stored result rather than running the task a second time. The request ID keeps both attempts connected in diagnostics.
 
 `TransportRequestContext` is an immutable request-scoped value:
 
@@ -251,9 +318,13 @@ TransportRequestContext(
 
 Server-side keys are namespaced by method and path. The first request owns the operation; concurrent duplicates await its result, and later duplicates replay the completed result until the TTL expires. This cache is process-local. Use a durable application-level idempotency store as well when operations must remain deduplicated across restarts or multiple server replicas.
 
+The TTL and cache size are memory bounds, not correctness guarantees. Once an entry expires or is evicted, the transport no longer remembers the operation. Deployments requiring long-lived exactly-once business effects should enforce a durable unique operation key in their storage layer as well.
+
 ### `TransportCapabilities`
 
 Every transport declares immutable class-level capabilities. Applications normally inspect `transport.capabilities`; custom transports set the class attribute.
+
+Capabilities let generic code ask what a transport can do without checking concrete class names. For example, a dashboard can show whether TLS is native, and a client can decide whether live streaming is available. They describe supported behavior, not current health: `streaming=True` means the implementation supports streams even when its server is currently stopped.
 
 ```python
 TransportCapabilities(
@@ -279,6 +350,10 @@ TransportCapabilities(
 
 Application code usually receives a transport from `Agent.transport` or `AgentClient.transport`. The stable inspection surface is:
 
+The base class exists so reliability behavior is not reimplemented differently in every protocol. HTTP still owns HTTP requests, gRPC still owns channels and metadata, and WebSocket still owns frames and connections; the base class supplies the protocol-neutral limits, retry decisions, metrics, correlation, deduplication, and lifecycle bookkeeping around them.
+
+Most users should not call `send()` or the extension hooks directly. Use `AgentClient` for task-level operations and inspect `config`, `capabilities`, `metrics`, and `health()` when operational state is needed.
+
 | Member | Type | Purpose |
 |--------|------|---------|
 | `transport_type` | `ClassVar[str]` | Factory/card identifier such as `"http"`, `"grpc"`, or `"runtime"`. |
@@ -297,6 +372,8 @@ Application code usually receives a transport from `Agent.transport` or `AgentCl
 #### Custom transport contract
 
 A custom transport subclasses `Transport`, calls `super().__init__(config=config)`, declares its class capabilities, and implements `send`, `setup_routes`, `start`, `stop`, `validate_url`, and `url`. Streaming transports also override `subscribe`.
+
+The split is intentional: the custom class implements the wire protocol, while the inherited helpers preserve the same safety contract as built-in transports. A typical outbound implementation creates a request context, checks the request size, enters `request_slot()`, and calls `run_with_retries()` around the actual protocol operation. An inbound implementation enters `inbound_request_slot()`, claims any idempotency key, invokes the endpoint, checks the response, and then completes or aborts the idempotent result.
 
 The base class exposes reusable extension hooks so custom transports can preserve the built-in operational contract:
 
@@ -322,6 +399,8 @@ These hooks are an extension API for transport authors. Normal agent application
 
 The base constructor creates the following private variables. They explain lifecycle behavior but are not a public mutation surface:
 
+These variables are documented so transport authors can understand ownership and debugging output, not so applications can modify them. In particular, asyncio semaphores and client connections belong to the event loop that created them. The per-loop maps prevent an Agent started in a background thread from accidentally reusing an asyncio resource on the caller's loop.
+
 | Variable | Role |
 |----------|------|
 | `_metrics` | Thread-safe mutable recorder behind the immutable `metrics` property. |
@@ -340,6 +419,8 @@ Do not replace or mutate these collections from application code. A custom trans
 
 `transport.metrics` returns a new immutable snapshot. Reading it does not reset counters.
 
+The built-in metrics are deliberately small and dependency-free. They answer immediate questions such as “are requests failing?”, “is the concurrency limit saturated?”, and “are retries hiding an unstable connection?” without requiring Prometheus, OpenTelemetry, or another backend. Because snapshots are local to one transport instance and reset on process restart, production monitoring should periodically export them or use ProtoLink telemetry for durable analysis.
+
 | Field | Type | Meaning |
 |-------|------|---------|
 | `requests_started` | `int` | Unary request executions admitted by this instance. |
@@ -357,9 +438,13 @@ Do not replace or mutate these collections from application code. A custom trans
 
 `snapshot.to_dict()` produces the exact JSON-compatible mapping embedded in health responses. Metrics are process-local operational counters, not a replacement for durable telemetry. Set `collect_metrics=False` when another layer owns all measurement.
 
+For a rough average unary latency, divide `total_latency_ms` by the number of completed requests (`requests_succeeded + requests_failed`). Do not use this value as a percentile: a cumulative total cannot show whether a small number of requests were unusually slow.
+
 ### Transport errors
 
 All transport exceptions inherit from `TransportError` and expose the same diagnostic attributes:
+
+Typed errors let application code react to failure categories without parsing human-readable messages or knowing which protocol was used. A caller can handle `TransportTimeoutError` the same way for HTTP and gRPC, while still reading the native `status_code` when protocol-specific diagnostics are useful.
 
 ```python
 TransportError(
@@ -382,6 +467,8 @@ TransportError(
 
 `retryable` describes the failure category only; the request spec and method must still permit retries. `status_code` is an HTTP integer or protocol-native string such as a gRPC status name. `request_id` lets logs and traces correlate the exception with request headers or envelopes.
 
+The subclasses also inherit familiar Python exception types where useful. For example, `TransportConnectionError` is both a `TransportError` and a `ConnectionError`. Existing code that catches the standard exception remains compatible, while new code can use the richer transport metadata.
+
 ```python
 try:
     result = await client.send_task(agent_url, task)
@@ -398,6 +485,14 @@ except TransportError as exc:
 ```
 
 ### Health and readiness
+
+Health endpoints exist for process managers, container orchestrators, load balancers, and human diagnostics. They provide a cheap answer without submitting a real task or requiring model-provider access.
+
+- `transport.health()` is useful from Python code and always returns JSON-safe data.
+- `GET /healthz` and `GET /readyz` expose the same conservative payload over HTTP-compatible Agent and Registry servers.
+- The `ready` field is `True` only after the transport starts serving and becomes `False` after shutdown.
+
+ProtoLink currently gives both HTTP probe paths the same payload. Deployments can use `/healthz` for general monitoring and `/readyz` for traffic admission; the shared `ready` flag ensures a stopped transport is not treated as ready for requests.
 
 `transport.health()` returns this transport-neutral shape:
 

--- a/docs/content/transport.md
+++ b/docs/content/transport.md
@@ -315,7 +315,7 @@ TransportRequestContext(
 | gRPC | Envelope `id` and `x-protolink-request-id` metadata | Envelope `idempotency_key` and `idempotency-key` metadata |
 | Runtime | In-process `TransportRequestContext` | In-process namespaced operation key |
 
-Server-side keys are namespaced by method and path. The first request owns the operation; concurrent duplicates await its result, and later duplicates replay the completed result until the TTL expires. This cache is process-local. Use a durable application-level idempotency store as well when operations must remain deduplicated across restarts or multiple server replicas.
+Server-side keys are namespaced by method and path. The first request owns the operation; concurrent duplicates await its result, and later duplicates replay the completed result until the TTL expires. Failed or cancelled operations are released rather than cached, so a later request can try the operation again. This cache is process-local. Use a durable application-level idempotency store as well when operations must remain deduplicated across restarts or multiple server replicas.
 
 The TTL and cache size are memory bounds, not correctness guarantees. Once an entry expires or is evicted, the transport no longer remembers the operation. Deployments requiring long-lived exactly-once business effects should enforce a durable unique operation key in their storage layer as well.
 

--- a/docs/src/pages/index.jsx
+++ b/docs/src/pages/index.jsx
@@ -127,7 +127,6 @@ const moduleDefinitions = [
           '    cafile="certs/ca.pem",',
           ")",
         ],
-        agentArg: "tls=tls",
       },
       {
         id: "mutual-tls",
@@ -142,7 +141,6 @@ const moduleDefinitions = [
           "    require_client_cert=True,",
           ")",
         ],
-        agentArg: "tls=tls",
       },
     ],
   },
@@ -407,6 +405,7 @@ const moduleDefinitions = [
         kind: "network",
         cardUrl: "http://127.0.0.1:8000",
         secureCardUrl: "https://127.0.0.1:8000",
+        transportClass: "HTTPTransport",
         agentArg: 'transport="http"',
       },
       {
@@ -414,6 +413,7 @@ const moduleDefinitions = [
         label: "Runtime",
         kind: "in-process",
         cardUrl: "runtime://assistant",
+        transportClass: "RuntimeTransport",
         agentArg: 'transport="runtime"',
       },
       {
@@ -422,6 +422,7 @@ const moduleDefinitions = [
         kind: "duplex",
         cardUrl: "ws://127.0.0.1:8000",
         secureCardUrl: "wss://127.0.0.1:8000",
+        transportClass: "WebSocketTransport",
         agentArg: 'transport="websocket"',
       },
       {
@@ -430,6 +431,7 @@ const moduleDefinitions = [
         kind: "rpc",
         cardUrl: "grpc://127.0.0.1:8000",
         secureCardUrl: "grpcs://127.0.0.1:8000",
+        transportClass: "GRPCTransport",
         agentArg: 'transport="grpc"',
       },
       {
@@ -438,6 +440,7 @@ const moduleDefinitions = [
         kind: "sse",
         cardUrl: "http://127.0.0.1:8000",
         secureCardUrl: "https://127.0.0.1:8000",
+        transportClass: "SSEJSONRPCTransport",
         agentArg: 'transport="json-rpc"',
       },
     ],
@@ -495,7 +498,6 @@ const moduleDefinitions = [
           "    retry=RetryPolicy(max_attempts=3),",
           ")",
         ],
-        agentArg: "transport_config=transport_config",
       },
       {
         id: "limits-only",
@@ -510,7 +512,6 @@ const moduleDefinitions = [
           "    ),",
           ")",
         ],
-        agentArg: "transport_config=transport_config",
       },
     ],
   },
@@ -564,6 +565,7 @@ function selectedTransportOption(activeModules, selectedOptions) {
   ) {
     return {
       cardUrl: "runtime://assistant",
+      transportClass: "RuntimeTransport",
     };
   }
 
@@ -834,6 +836,10 @@ function buildAgentCode(activeModules, selectedOptions) {
   const tlsEnabled =
     activeModules.some((module) => module.id === "tls") &&
     Boolean(transportOption.secureCardUrl);
+  const resilienceEnabled = activeModules.some(
+    (module) => module.id === "resilience",
+  );
+  const advancedTransport = tlsEnabled || resilienceEnabled;
   const cardUrl = tlsEnabled
     ? transportOption.secureCardUrl
     : transportOption.cardUrl;
@@ -851,12 +857,29 @@ function buildAgentCode(activeModules, selectedOptions) {
     resolvedModule.imports?.forEach((line) => imports.add(line));
     resolvedModule.setup?.forEach((line) => setupLines.push(line));
 
-    if (resolvedModule.agentArg) {
+    if (
+      resolvedModule.agentArg &&
+      !(advancedTransport && module.id === "transport")
+    ) {
       constructorArgs.push(resolvedModule.agentArg);
     }
 
     resolvedModule.after?.forEach((line) => afterLines.push(line));
   });
+
+  if (advancedTransport) {
+    imports.add(
+      `from protolink.transport import ${transportOption.transportClass}`,
+    );
+    setupLines.push(
+      `transport = ${transportOption.transportClass}(`,
+      `    url="${cardUrl}",`,
+      ...(tlsEnabled ? ["    tls=tls,"] : []),
+      ...(resilienceEnabled ? ["    config=transport_config,"] : []),
+      ")",
+    );
+    constructorArgs.push("transport=transport");
+  }
 
   return [
     ...Array.from(imports),

--- a/docs/src/pages/index.jsx
+++ b/docs/src/pages/index.jsx
@@ -472,6 +472,48 @@ const moduleDefinitions = [
       },
     ],
   },
+  {
+    id: "resilience",
+    label: "Resilience",
+    detail: "limits and retries",
+    badge: "RS",
+    tone: "blue",
+    options: [
+      {
+        id: "production",
+        label: "Production",
+        kind: "bounded",
+        imports: [
+          "from protolink import RetryPolicy, TransportConfig, TransportLimits",
+        ],
+        setup: [
+          "transport_config = TransportConfig(",
+          "    limits=TransportLimits(",
+          "        max_concurrent_requests=200,",
+          "        max_concurrent_streams=50,",
+          "    ),",
+          "    retry=RetryPolicy(max_attempts=3),",
+          ")",
+        ],
+        agentArg: "transport_config=transport_config",
+      },
+      {
+        id: "limits-only",
+        label: "Limits only",
+        kind: "no retries",
+        imports: ["from protolink import TransportConfig, TransportLimits"],
+        setup: [
+          "transport_config = TransportConfig(",
+          "    limits=TransportLimits(",
+          "        max_request_bytes=8 * 1024 * 1024,",
+          "        max_concurrent_requests=100,",
+          "    ),",
+          ")",
+        ],
+        agentArg: "transport_config=transport_config",
+      },
+    ],
+  },
 ];
 
 const plugModules = [...moduleDefinitions].sort((left, right) => {

--- a/examples/tls_agent.py
+++ b/examples/tls_agent.py
@@ -76,7 +76,13 @@ def main() -> None:
         llm=create_llm("mock", default_response="hello over TLS"),
         verbosity=0,
     )
-    client = AgentClient("http", url="http://127.0.0.1:0", tls=client_tls)
+    client_transport = HTTPTransport(
+        "http://127.0.0.1:0",
+        tls=client_tls,
+        log_level="critical",
+        access_log=False,
+    )
+    client = AgentClient(client_transport)
 
     try:
         agent.start(register=False, background=True)

--- a/examples/tls_agent.py
+++ b/examples/tls_agent.py
@@ -21,6 +21,7 @@ from pathlib import Path
 
 from protolink import Agent, AgentCard, Task, TLSConfig, create_llm
 from protolink.client import AgentClient
+from protolink.transport import HTTPTransport
 
 
 def find_free_port() -> int:
@@ -63,10 +64,15 @@ def main() -> None:
         cafile=args.cafile,
     )
 
+    transport = HTTPTransport(
+        agent_url,
+        tls=server_tls,
+        log_level="critical",
+        access_log=False,
+    )
     agent = Agent(
         AgentCard(name="secure-agent", description="Agent served over HTTPS", url=agent_url),
-        transport="http",
-        tls=server_tls,
+        transport=transport,
         llm=create_llm("mock", default_response="hello over TLS"),
         verbosity=0,
     )

--- a/examples/transport_production.py
+++ b/examples/transport_production.py
@@ -1,0 +1,61 @@
+"""Configure production transport behavior through the high-level Agent API.
+
+This provider-free example uses RuntimeTransport so it can run without opening
+a network port. The same ``TransportConfig`` works unchanged with HTTP, SSE
+JSON-RPC, WebSocket, and gRPC transports.
+"""
+
+from protolink import (
+    Agent,
+    AgentCard,
+    AgentInterface,
+    RetryPolicy,
+    TransportConfig,
+    TransportLimits,
+)
+
+
+def main() -> None:
+    """Start a bounded local agent and inspect transport health and metrics."""
+    transport_config = TransportConfig(
+        limits=TransportLimits(
+            max_request_bytes=8 * 1024 * 1024,
+            max_response_bytes=8 * 1024 * 1024,
+            max_event_bytes=1024 * 1024,
+            max_concurrent_requests=100,
+            max_concurrent_streams=25,
+        ),
+        retry=RetryPolicy(max_attempts=3),
+        keepalive_interval=20,
+        keepalive_timeout=10,
+        shutdown_timeout=10,
+    )
+    card = AgentCard(
+        name="production-worker",
+        description="Provider-free transport configuration example",
+        url="runtime://production-worker",
+        interfaces=[
+            AgentInterface(
+                url="grpcs://worker.internal:9443",
+                transport="grpc",
+            )
+        ],
+    )
+    agent = Agent(
+        card=card,
+        transport="runtime",
+        transport_config=transport_config,
+        verbosity=0,
+    )
+
+    agent.start(register=False, background=True)
+    try:
+        health = agent.transport.health() if agent.transport is not None else {}
+        print(health["status"])
+        print(health["metrics"])
+    finally:
+        agent.stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/transport_production.py
+++ b/examples/transport_production.py
@@ -1,4 +1,4 @@
-"""Configure production transport behavior through the high-level Agent API.
+"""Configure production transport behavior on a concrete transport.
 
 This provider-free example uses RuntimeTransport so it can run without opening
 a network port. The same ``TransportConfig`` works unchanged with HTTP, SSE
@@ -13,6 +13,7 @@ from protolink import (
     TransportConfig,
     TransportLimits,
 )
+from protolink.transport import RuntimeTransport
 
 
 def main() -> None:
@@ -41,10 +42,10 @@ def main() -> None:
             )
         ],
     )
+    transport = RuntimeTransport(card.url, config=transport_config)
     agent = Agent(
         card=card,
-        transport="runtime",
-        transport_config=transport_config,
+        transport=transport,
         verbosity=0,
     )
 

--- a/protolink/__init__.py
+++ b/protolink/__init__.py
@@ -52,12 +52,24 @@ from protolink.llms import (
     build_context_manifest,
     create_llm,
 )
-from protolink.models import AgentCard, AgentSkill, Artifact, Message, Part, Task, TaskState
+from protolink.models import AgentCard, AgentInterface, AgentSkill, Artifact, Message, Part, Task, TaskState
 from protolink.security import TLSConfig
 from protolink.state import StateOperationRequest, StateOperationResult, StateStoreReport
 from protolink.storage import RunReportRecord, RunStore, SQLiteRunStore, TaskRecord
 from protolink.telemetry import LocalTraceRecorder, LocalTraceTelemetry
 from protolink.tools import BaseTool, Tool
+from protolink.transport import (
+    RetryPolicy,
+    TransportConfig,
+    TransportConnectionError,
+    TransportError,
+    TransportLimitError,
+    TransportLimits,
+    TransportMetricsSnapshot,
+    TransportProtocolError,
+    TransportRemoteError,
+    TransportTimeoutError,
+)
 
 __all__ = [
     "DEFAULT_REDACTION_POLICY",
@@ -67,6 +79,7 @@ __all__ = [
     "ActionPolicyError",
     "Agent",
     "AgentCard",
+    "AgentInterface",
     "AgentSkill",
     "ApprovalDecision",
     "ApprovalHandler",
@@ -103,6 +116,7 @@ __all__ = [
     "PolicyDecision",
     "PolicyEffect",
     "RedactionPolicy",
+    "RetryPolicy",
     "Router",
     "RunAction",
     "RunBudget",
@@ -127,6 +141,15 @@ __all__ = [
     "TaskRecord",
     "TaskState",
     "Tool",
+    "TransportConfig",
+    "TransportConnectionError",
+    "TransportError",
+    "TransportLimitError",
+    "TransportLimits",
+    "TransportMetricsSnapshot",
+    "TransportProtocolError",
+    "TransportRemoteError",
+    "TransportTimeoutError",
     "__version__",
     "assert_budget_under",
     "assert_no_denied_actions",

--- a/protolink/__init__.py
+++ b/protolink/__init__.py
@@ -1,3 +1,5 @@
+"""Public convenience exports for the ProtoLink agent runtime."""
+
 from protolink.__version__ import __version__
 from protolink.agents import Agent
 from protolink.core import (

--- a/protolink/agents/_typing.py
+++ b/protolink/agents/_typing.py
@@ -16,7 +16,6 @@ if TYPE_CHECKING:
     from protolink.llms.compaction import HistoryCompactionRequest, HistoryCompactionResult
     from protolink.logging import BaseLogger
     from protolink.models import AgentCard, AgentSkill, Part, Task
-    from protolink.security.tls import TLSConfig
     from protolink.server import AgentServer
     from protolink.state import State
     from protolink.state.operations import StateOperationRequest, StateOperationResult
@@ -36,7 +35,6 @@ class _AgentMixinBase(Protocol):
     registry_client: RegistryClient | None
     authenticator: Any
     credentials: str | None
-    tls: TLSConfig | None
     override_system_prompt: bool
     start_time: float | None
 

--- a/protolink/agents/base.py
+++ b/protolink/agents/base.py
@@ -19,12 +19,11 @@ from protolink.llms.base import LLM
 from protolink.logging import BaseLogger, ConsoleLogger
 from protolink.models import AgentCard
 from protolink.security.auth import Authenticator
-from protolink.security.tls import TLSConfig
 from protolink.state import State
 from protolink.storage import InMemoryStorage, Storage
 from protolink.telemetry.base import Telemetry
 from protolink.tools import BaseTool
-from protolink.transport import Transport, TransportConfig
+from protolink.transport import Transport
 from protolink.types import StateMode, TransportType
 
 from .engine import AgentExecutionMixin
@@ -79,8 +78,6 @@ class Agent(
         expose_chat: bool = True,
         authenticator: Authenticator | None = None,
         credentials: str | None = None,
-        tls: TLSConfig | None = None,
-        transport_config: TransportConfig | None = None,
         policy: Policy | None = None,
         approval_handler: ApprovalHandlerLike | None = None,
         run_store: Any | None = None,
@@ -92,10 +89,12 @@ class Agent(
             card: AgentCard or dict describing this agent's identity and capabilities.
             transport: Transport instance or transport type string. If a Transport object is provided, it's used
                 directly. If a string is provided (e.g., "http", "websocket"), a new Transport instance is created
-                (transport factory) using the agent's card URL.
+                with default settings using the agent's card URL. Configure TLS, limits, retries, keepalive, and
+                protocol-specific behavior on a concrete Transport before passing it to Agent.
             registry: Registry instance, RegistryClient, or transport type string. If a Registry object is provided,
                 its RegistryClient is extracted. If a RegistryClient is provided, it's used directly.
-                If a string is provided, a new RegistryClient is created using the transport factory with registry_url.
+                If a string is provided, a new RegistryClient is created with default transport settings using
+                registry_url. Pass a configured RegistryClient for advanced registry transport behavior.
             registry_url: URL of registry when using string transport type for registry creation.
             llm: Optional LLM instance for agent reasoning and inference.
             system_prompt: This is used as complementary text in the system prompt, which is responsible for explaining
@@ -117,10 +116,6 @@ class Agent(
             expose_chat: Whether the Agent will expose a chat endpoint for interaction with a UI.
             authenticator: Optional Authenticator instance for verifying incoming requests to this agent.
             credentials: Optional credentials string used for authenticating outgoing requests.
-            tls: Optional transport-security configuration. Secure agent and registry
-                URLs use it for certificate trust, server identity, and mutual TLS.
-            transport_config: Shared transport limits, retry, keepalive, shutdown,
-                idempotency, and metrics configuration.
             policy: Optional runtime policy evaluated before concrete actions execute.
                 Defaults to a backward-compatible ``CapabilityPolicy`` that
                 allows actions unless a tool or ``RunContext`` rule restricts
@@ -186,8 +181,6 @@ class Agent(
         # Store authentication configuration
         self.authenticator: Authenticator | None = authenticator
         self.credentials: str | None = credentials
-        self.tls = tls
-        self.transport_config = transport_config
         # Initialize client and server components
         if transport is None:
             self._transport, self._client, self._server = None, None, None

--- a/protolink/agents/base.py
+++ b/protolink/agents/base.py
@@ -24,7 +24,7 @@ from protolink.state import State
 from protolink.storage import InMemoryStorage, Storage
 from protolink.telemetry.base import Telemetry
 from protolink.tools import BaseTool
-from protolink.transport import Transport
+from protolink.transport import Transport, TransportConfig
 from protolink.types import StateMode, TransportType
 
 from .engine import AgentExecutionMixin
@@ -80,6 +80,7 @@ class Agent(
         authenticator: Authenticator | None = None,
         credentials: str | None = None,
         tls: TLSConfig | None = None,
+        transport_config: TransportConfig | None = None,
         policy: Policy | None = None,
         approval_handler: ApprovalHandlerLike | None = None,
         run_store: Any | None = None,
@@ -118,6 +119,8 @@ class Agent(
             credentials: Optional credentials string used for authenticating outgoing requests.
             tls: Optional transport-security configuration. Secure agent and registry
                 URLs use it for certificate trust, server identity, and mutual TLS.
+            transport_config: Shared transport limits, retry, keepalive, shutdown,
+                idempotency, and metrics configuration.
             policy: Optional runtime policy evaluated before concrete actions execute.
                 Defaults to a backward-compatible ``CapabilityPolicy`` that
                 allows actions unless a tool or ``RunContext`` rule restricts
@@ -184,6 +187,7 @@ class Agent(
         self.authenticator: Authenticator | None = authenticator
         self.credentials: str | None = credentials
         self.tls = tls
+        self.transport_config = transport_config
         # Initialize client and server components
         if transport is None:
             self._transport, self._client, self._server = None, None, None

--- a/protolink/agents/mixins.py
+++ b/protolink/agents/mixins.py
@@ -30,7 +30,7 @@ from protolink.storage import Storage
 from protolink.telemetry.base import Telemetry
 from protolink.tools import ActionBuilder, BaseTool, Tool
 from protolink.tools.schema import validate_tool_args
-from protolink.transport import Transport, get_transport
+from protolink.transport import Transport, TransportConfig, get_transport
 from protolink.types import TransportType
 from protolink.utils.renderers.chat import to_chat_html
 from protolink.utils.renderers.status import to_status_html
@@ -1052,6 +1052,9 @@ class AgentConfigurationMixin(_AgentMixinBase):
             }
             if tls is not None:
                 transport_kwargs["tls"] = tls
+            transport_config = getattr(self, "transport_config", None)
+            if transport_config is not None:
+                transport_kwargs["config"] = transport_config
             if getattr(self, "_verbosity", 1) == 0:
                 transport_kwargs["log_level"] = "critical"
                 transport_kwargs["access_log"] = False
@@ -1253,6 +1256,9 @@ class AgentConfigurationMixin(_AgentMixinBase):
                 transport_kwargs: dict[str, Any] = {"url": registry_url}
                 if self.tls is not None:
                     transport_kwargs["tls"] = self.tls
+                transport_config = getattr(self, "transport_config", None)
+                if transport_config is not None:
+                    transport_kwargs["config"] = transport_config
                 transport = get_transport(registry, **transport_kwargs)
                 self.registry_client = RegistryClient(transport=transport)
             elif isinstance(registry, RegistryClient):
@@ -1421,6 +1427,7 @@ class AgentSerializationMixin(_AgentMixinBase):
                 "url": self._transport.url,
                 "timeout": getattr(self._transport, "timeout", 360.0),
             }
+            transport_config["config"] = self._transport.config.to_dict()
             if hasattr(self._transport, "backend"):
                 backend_name = "starlette"
                 if "FastAPIBackend" in self._transport.backend.__class__.__name__:
@@ -1543,10 +1550,13 @@ class AgentSerializationMixin(_AgentMixinBase):
 
         # Transport
         transport = overrides.get("transport")
+        shared_transport_config = overrides.get("transport_config")
         if transport is None:
             transport_config = data.get("transport")
             if transport_config:
                 transport_type = transport_config.get("type", "http")
+                if shared_transport_config is None and isinstance(transport_config.get("config"), dict):
+                    shared_transport_config = TransportConfig.from_dict(transport_config["config"])
                 try:
                     from protolink.transport import get_transport
 
@@ -1562,6 +1572,8 @@ class AgentSerializationMixin(_AgentMixinBase):
                     t_kwargs["authenticator"] = authenticator
                     t_kwargs["credentials"] = credentials
                     t_kwargs["tls"] = tls
+                    if shared_transport_config is not None:
+                        t_kwargs["config"] = shared_transport_config
 
                     transport = get_transport(transport_type, **t_kwargs)
                 except Exception:
@@ -1637,6 +1649,7 @@ class AgentSerializationMixin(_AgentMixinBase):
             authenticator=authenticator,
             credentials=credentials,
             tls=tls,
+            transport_config=shared_transport_config,
         )
 
         tools_data = data.get("tools", [])

--- a/protolink/agents/mixins.py
+++ b/protolink/agents/mixins.py
@@ -1396,9 +1396,7 @@ class AgentSerializationMixin(_AgentMixinBase):
         if tls is not None:
             data["tls"] = tls.to_dict()
         if hasattr(transport, "backend"):
-            data["backend"] = (
-                "fastapi" if "FastAPIBackend" in transport.backend.__class__.__name__ else "starlette"
-            )
+            data["backend"] = "fastapi" if "FastAPIBackend" in transport.backend.__class__.__name__ else "starlette"
             if hasattr(transport.backend, "validate_schema"):
                 data["validate_schema"] = getattr(transport.backend, "validate_schema", False)
         return data

--- a/protolink/agents/mixins.py
+++ b/protolink/agents/mixins.py
@@ -1,8 +1,7 @@
 """Reusable behavior mixins for the public Agent class.
 
-These mixins keep the public :class:`protolink.agents.Agent` API stable while
-separating independent responsibilities such as lifecycle, control-plane
-operations, tools, registry communication, configuration, and serialization.
+These mixins keep the public :class:`protolink.agents.Agent` API stable while separating independent responsibilities
+such as lifecycle, control-plane operations, tools, registry communication, configuration, and serialization.
 """
 
 from __future__ import annotations
@@ -93,8 +92,7 @@ class AgentLifecycleMixin(_AgentMixinBase):
     async def _serve_forever(self) -> None:
         """Keep the agent runtime alive until cancellation.
 
-        This method blocks indefinitely and gracefully shuts down the
-        agent when cancellation occurs.
+        This method blocks indefinitely and gracefully shuts down the agent when cancellation occurs.
         """
 
         try:
@@ -159,8 +157,8 @@ class AgentLifecycleMixin(_AgentMixinBase):
     ) -> None:
         """Start the agent runtime and initialize outbound/inbound communications.
 
-        This is the primary public entrypoint for running the agent. It is designed to be
-        environment-agnostic, working seamlessly in:
+        This is the primary public entrypoint for running the agent. It is designed to be environment-agnostic, working
+        seamlessly in:
         - standard scripts
         - async applications
         - background threads
@@ -168,18 +166,16 @@ class AgentLifecycleMixin(_AgentMixinBase):
 
 
         **Technical Note on Lifecycle Orchestration:**
-        Protolink handles the transition between synchronous and asynchronous contexts using
-        a dual-mode execution strategy:
+        Protolink handles the transition between synchronous and asynchronous contexts using a dual-mode execution
+        strategy:
 
-        1. **Deterministic Background Mode (``background=True``):** Starts a dedicated thread
-           with its own ``asyncio`` event loop. To prevent race conditions, this method
-           utilizes a ``threading.Event`` to block the caller until the background agent is
-           fully initialized, registered, and ready to receive traffic. Any startup
-           failures (e.g., port collisions) are captured and re-raised in the caller thread.
+        1. **Deterministic Background Mode (``background=True``):** Starts a dedicated thread with its own ``asyncio``
+           event loop. To prevent race conditions, this method utilizes a ``threading.Event`` to block the caller until
+           the background agent is fully initialized, registered, and ready to receive traffic. Any startup failures
+           (e.g., port collisions) are captured and re-raised in the caller thread.
 
-        2. **Blocking Mode (``background=False``):** Utilizes ``asyncio.run()`` to take over
-            the main thread's execution. This is the recommended pattern for standalone
-           agent scripts.
+        2. **Blocking Mode (``background=False``):** Utilizes ``asyncio.run()`` to take over the main thread's
+           execution. This is the recommended pattern for standalone agent scripts.
 
         Args:
             register: If True, registers the agent with the configured registry upon startup.
@@ -272,15 +268,14 @@ class AgentLifecycleMixin(_AgentMixinBase):
         It is specifically designed to safely terminate agents started with ``background=True``.
 
         **Technical Note on Thread-Safe Teardown:**
-        When an agent is running in a background thread, its lifecycle is managed by a private event loop.
-        To stop it from the main thread, we utilize ``call_soon_threadsafe`` to inject a cancellation request into
-        the background loop. This triggers a ``CancelledError`` within the ``_lifecycle()`` coroutine, allowing
-        it to execute its ``finally`` blocks which perform critical cleanup like closing the transport and stopping
-        the ASGI server.
+        When an agent is running in a background thread, its lifecycle is managed by a private event loop. To stop it
+        from the main thread, we utilize ``call_soon_threadsafe`` to inject a cancellation request into the background
+        loop. This triggers a ``CancelledError`` within the ``_lifecycle()`` coroutine, allowing it to execute its
+        ``finally`` blocks which perform critical cleanup like closing the transport and stopping the ASGI server.
 
-        The subsequent ``join(timeout=10)`` synchronizes the main thread with the background thread's exit.
-        This ensures that the caller doesn't proceed (or the process doesn't exit) while the background server
-        is still in the middle of a graceful port release or connection drain.
+        The subsequent ``join(timeout=10)`` synchronizes the main thread with the background thread's exit. This ensures
+        that the caller doesn't proceed (or the process doesn't exit) while the background server is still in the middle
+        of a graceful port release or connection drain.
 
         Notes:
             - Safe to call multiple times.
@@ -305,18 +300,16 @@ class AgentControlPlaneMixin(_AgentMixinBase):
     def active_task_ids(self) -> tuple[str, ...]:
         """Return task IDs currently executing on this Agent.
 
-        This is a process-local runtime view intended for diagnostics and
-        control planes. Completed tasks are removed immediately and should be
-        retrieved from application storage rather than this active registry.
+        This is a process-local runtime view intended for diagnostics and control planes. Completed tasks are removed
+        immediately and should be retrieved from application storage rather than this active registry.
         """
         return self._task_executions.task_ids
 
     def get_cancellation_token(self, task_id: str) -> CancellationToken | None:
         """Return the live cooperative token for an active task.
 
-        Custom handlers may use this token to add cancellation checkpoints
-        inside long-running loops. The token is never serialized into ``Task``
-        or ``RunContext``.
+        Custom handlers may use this token to add cancellation checkpoints inside long-running loops. The token is never
+        serialized into ``Task`` or ``RunContext``.
         """
         return self._task_executions.get_token(task_id)
 
@@ -327,15 +320,14 @@ class AgentControlPlaneMixin(_AgentMixinBase):
     ) -> Task:
         """Request best-effort cancellation of an active task.
 
-        Cancellation updates both the protocol ``Task`` state and serialized
-        ``RunContext``, then interrupts the owning ``asyncio.Task`` at its next
-        await point. Synchronous functions and already-issued external side
-        effects may not be immediately stoppable.
+        Cancellation updates both the protocol ``Task`` state and serialized ``RunContext``, then interrupts the owning
+        ``asyncio.Task`` at its next await point. Synchronous functions and already-issued external side effects may not
+        be immediately stoppable.
 
         Args:
             request: Active task ID or a typed A2A-style cancellation request.
-            reason: Optional reason used when ``request`` is a task ID. When a
-                typed request is supplied, an explicit argument takes precedence.
+            reason: Optional reason used when ``request`` is a task ID. When a typed request is supplied, an explicit
+                argument takes precedence.
 
         Returns:
             The active task after its state changes to ``canceled``.
@@ -358,15 +350,13 @@ class AgentControlPlaneMixin(_AgentMixinBase):
     ) -> HistoryCompactionResult:
         """Compact this agent's LLM history through a control-plane request.
 
-        This method backs the ``/llm/history/compact`` endpoint and the
-        matching ``AgentClient`` request spec. It is intentionally outside
-        ``Task`` execution and outside ``LLM.infer()``, so compaction is never
-        advertised to the model as a tool and never consumes prompt budget.
+        This method backs the ``/llm/history/compact`` endpoint and the matching ``AgentClient`` request spec. It is
+        intentionally outside ``Task`` execution and outside ``LLM.infer()``, so compaction is never advertised to the
+        model as a tool and never consumes prompt budget.
 
-        When ``request.session_id`` is provided and conversation state is
-        enabled, the session history is loaded before compaction and saved
-        afterward. The operation is authorized through the
-        ``llm.history.compact`` runtime capability before any history mutation.
+        When ``request.session_id`` is provided and conversation state is enabled, the session history is loaded before
+        compaction and saved afterward. The operation is authorized through the ``llm.history.compact`` runtime
+        capability before any history mutation.
         """
         if self.llm is None:
             raise RuntimeError("Agent has no LLM but received a history compaction request")
@@ -426,9 +416,8 @@ class AgentControlPlaneMixin(_AgentMixinBase):
     ) -> StateOperationResult:
         """Describe enabled state stores through the control plane.
 
-        This method reports what state stores are enabled and, for conversation
-        state, whether a specific session exists. It does not expose a model
-        tool and does not mutate state.
+        This method reports what state stores are enabled and, for conversation state, whether a specific session
+        exists. It does not expose a model tool and does not mutate state.
         """
         active_request = _coerce_state_operation_request(
             request,
@@ -454,10 +443,9 @@ class AgentControlPlaneMixin(_AgentMixinBase):
     ) -> StateOperationResult:
         """Reset persistent state and return a structured report.
 
-        Passing a ``session_id`` precisely clears conversation state for that
-        session. Omitting ``session_id`` performs a full agent-state reset for
-        all enabled stores. Partial full resets are rejected because the current
-        storage abstraction is namespace-based.
+        Passing a ``session_id`` precisely clears conversation state for that session. Omitting ``session_id`` performs
+        a full agent-state reset for all enabled stores. Partial full resets are rejected because the current storage
+        abstraction is namespace-based.
         """
         active_request = _coerce_state_operation_request(
             request,
@@ -486,11 +474,9 @@ class AgentControlPlaneMixin(_AgentMixinBase):
     ) -> StateOperationResult:
         """Compact persistent conversation state and return a state report.
 
-        Conversation state is currently the built-in compactable store. The
-        operation loads the selected session, runs the LLM-owned
-        ``HistoryCompactor``, saves the compacted session, and reports the
-        before/after counts. Explicit keyword arguments override fields on
-        ``request``; omitted keywords preserve request-spec values delivered by
+        Conversation state is currently the built-in compactable store. The operation loads the selected session, runs
+        the LLM-owned ``HistoryCompactor``, saves the compacted session, and reports the before/after counts. Explicit
+        keyword arguments override fields on ``request``; omitted keywords preserve request-spec values delivered by
         remote clients.
         """
         active_request = _coerce_state_operation_request(
@@ -794,8 +780,8 @@ class AgentToolMixin(_AgentMixinBase):
             tags: Optional discovery and presentation tags.
             examples: Optional usage examples.
             capabilities: Permission capabilities required before execution.
-            action_builder: Optional callable that enriches the prepared
-                ``RunAction`` with metadata or preview artifacts.
+            action_builder: Optional callable that enriches the prepared ``RunAction`` with metadata or preview
+                artifacts.
 
         Returns:
             A decorator that registers the wrapped callable on this agent.
@@ -823,9 +809,8 @@ class AgentToolMixin(_AgentMixinBase):
     async def call_tool(self, tool_name: str, **kwargs):
         """Invoke a registered tool after runtime policy authorization.
 
-        Direct calls use a fresh run context. Task-based execution uses the
-        context propagated on the task, allowing per-run permissions and
-        cancellation state to participate in the decision.
+        Direct calls use a fresh run context. Task-based execution uses the context propagated on the task, allowing
+        per-run permissions and cancellation state to participate in the decision.
         """
         tool = self.tools.get(tool_name, None)
         if not tool:
@@ -841,9 +826,8 @@ class AgentToolMixin(_AgentMixinBase):
     ) -> Any:
         """Invoke a registered tool using an explicit run context.
 
-        This variant is intended for application runtimes and deterministic
-        flows that call tools directly while preserving per-run permissions,
-        cancellation, trace correlation, and approval behavior.
+        This variant is intended for application runtimes and deterministic flows that call tools directly while
+        preserving per-run permissions, cancellation, trace correlation, and approval behavior.
 
         Args:
             tool_name: Name of the registered tool to invoke.
@@ -866,15 +850,13 @@ class AgentToolMixin(_AgentMixinBase):
     ) -> ActionAuthorization:
         """Authorize an arbitrary runtime action without executing it.
 
-        This public primitive supports deterministic flows and application
-        runtimes that prepare side effects outside the built-in tool dispatcher.
-        Tool execution paths call the same authorizer internally after enriching
-        actions with tool-declared capabilities and preview artifacts.
+        This public primitive supports deterministic flows and application runtimes that prepare side effects outside
+        the built-in tool dispatcher. Tool execution paths call the same authorizer internally after enriching actions
+        with tool-declared capabilities and preview artifacts.
 
         Args:
             action: Concrete operation to evaluate.
-            context: Optional active run context. A fresh context associated
-                with this agent is created when omitted.
+            context: Optional active run context. A fresh context associated with this agent is created when omitted.
 
         Returns:
             A successful authorization record.
@@ -968,10 +950,10 @@ class AgentToolMixin(_AgentMixinBase):
         """Automatically detect skills from available tools and methods.
 
         Args:
-            include_public_methods: Whether to automatically detect skills from public methods of the agent.
-                When True, scans all public methods (those not starting with '_') and creates
-                AgentSkill objects from them. When False, only detects skills from registered tools.
-                Defaults to False to avoid unintended exposure of all public methods as skills.
+            include_public_methods: Whether to automatically detect skills from public methods of the agent. When True,
+            scans all public methods (those not starting with '_') and creates AgentSkill objects from them. When False,
+            only detects skills from registered tools. Defaults to False to avoid unintended exposure of all public
+            methods as skills.
 
         Returns:
             List of AgentSkill objects detected from the agent
@@ -1174,8 +1156,7 @@ class AgentConfigurationMixin(_AgentMixinBase):
     async def handle_chat_message(self, data: dict[str, Any]) -> dict[str, str]:
         """Handle an incoming chat message from the chat UI.
 
-        Expects a JSON body with 'message' and optional 'session_id'.
-        Uses the agent's invoke() method under the hood.
+        Expects a JSON body with 'message' and optional 'session_id'. Uses the agent's invoke() method under the hood.
 
         Args:
             data: Dict with 'message' (str) and optional 'session_id' (str)
@@ -1581,6 +1562,7 @@ class AgentSerializationMixin(_AgentMixinBase):
                         cls._deserialize_transport(
                             registry_config,
                             fallback_url=registry_url or "",
+                            authenticator=authenticator,
                             credentials=credentials,
                         )
                     )

--- a/protolink/agents/mixins.py
+++ b/protolink/agents/mixins.py
@@ -1042,7 +1042,6 @@ class AgentConfigurationMixin(_AgentMixinBase):
 
         authenticator = getattr(self, "authenticator", None)
         credentials = getattr(self, "credentials", None)
-        tls = self.tls
 
         if isinstance(transport, str):
             transport_kwargs: dict[str, Any] = {
@@ -1050,11 +1049,6 @@ class AgentConfigurationMixin(_AgentMixinBase):
                 "authenticator": authenticator,
                 "credentials": credentials,
             }
-            if tls is not None:
-                transport_kwargs["tls"] = tls
-            transport_config = getattr(self, "transport_config", None)
-            if transport_config is not None:
-                transport_kwargs["config"] = transport_config
             if getattr(self, "_verbosity", 1) == 0:
                 transport_kwargs["log_level"] = "critical"
                 transport_kwargs["access_log"] = False
@@ -1068,8 +1062,6 @@ class AgentConfigurationMixin(_AgentMixinBase):
                 setattr(transport, "authenticator", authenticator)  # noqa: B010
             if credentials is not None and getattr(transport, "credentials", None) is None:
                 setattr(transport, "credentials", credentials)  # noqa: B010
-            if tls is not None and getattr(transport, "tls", None) is None and hasattr(transport, "tls"):
-                setattr(transport, "tls", tls)  # noqa: B010
         else:
             raise ValueError("Invalid transport type")
 
@@ -1253,13 +1245,7 @@ class AgentConfigurationMixin(_AgentMixinBase):
                 if registry_url is None:
                     self._logger.error("registry_url cannot be None")
                     return
-                transport_kwargs: dict[str, Any] = {"url": registry_url}
-                if self.tls is not None:
-                    transport_kwargs["tls"] = self.tls
-                transport_config = getattr(self, "transport_config", None)
-                if transport_config is not None:
-                    transport_kwargs["config"] = transport_config
-                transport = get_transport(registry, **transport_kwargs)
+                transport = get_transport(registry, url=registry_url)
                 self.registry_client = RegistryClient(transport=transport)
             elif isinstance(registry, RegistryClient):
                 self.registry_client = registry
@@ -1397,6 +1383,54 @@ class AgentSerializationMixin(_AgentMixinBase):
                 func=func,
             )
 
+    @staticmethod
+    def _serialize_transport(transport: Transport) -> dict[str, Any]:
+        """Serialize one transport with its independently owned settings."""
+        data: dict[str, Any] = {
+            "type": getattr(transport, "transport_type", "http"),
+            "url": transport.url,
+            "timeout": getattr(transport, "timeout", 360.0),
+            "config": transport.config.to_dict(),
+        }
+        tls = getattr(transport, "tls", None)
+        if tls is not None:
+            data["tls"] = tls.to_dict()
+        if hasattr(transport, "backend"):
+            data["backend"] = (
+                "fastapi" if "FastAPIBackend" in transport.backend.__class__.__name__ else "starlette"
+            )
+            if hasattr(transport.backend, "validate_schema"):
+                data["validate_schema"] = getattr(transport.backend, "validate_schema", False)
+        return data
+
+    @classmethod
+    def _deserialize_transport(
+        cls,
+        data: dict[str, Any],
+        *,
+        fallback_url: str,
+        authenticator: Any = None,
+        credentials: str | None = None,
+    ) -> Transport:
+        """Rebuild one transport without promoting its settings onto Agent."""
+        kwargs: dict[str, Any] = {
+            "url": data.get("url", fallback_url),
+            "timeout": data.get("timeout", 360.0),
+        }
+        if "backend" in data:
+            kwargs["backend"] = data["backend"]
+        if "validate_schema" in data:
+            kwargs["validate_schema"] = data["validate_schema"]
+        if isinstance(data.get("config"), dict):
+            kwargs["config"] = TransportConfig.from_dict(data["config"])
+        if isinstance(data.get("tls"), dict):
+            kwargs["tls"] = TLSConfig.from_dict(data["tls"])
+        if authenticator is not None:
+            kwargs["authenticator"] = authenticator
+        if credentials is not None:
+            kwargs["credentials"] = credentials
+        return get_transport(data.get("type", "http"), **kwargs)
+
     def to_dict(self) -> dict[str, Any]:
         """Serialize the agent configuration to a dictionary representation."""
         level = getattr(self._logger, "level", 20)
@@ -1417,32 +1451,13 @@ class AgentSerializationMixin(_AgentMixinBase):
             "credentials": self.credentials,
         }
 
-        if self.tls is not None:
-            data["tls"] = self.tls.to_dict()
-
         # Transport
         if self._transport:
-            transport_config = {
-                "type": getattr(self._transport, "transport_type", "http"),
-                "url": self._transport.url,
-                "timeout": getattr(self._transport, "timeout", 360.0),
-            }
-            transport_config["config"] = self._transport.config.to_dict()
-            if hasattr(self._transport, "backend"):
-                backend_name = "starlette"
-                if "FastAPIBackend" in self._transport.backend.__class__.__name__:
-                    backend_name = "fastapi"
-                transport_config["backend"] = backend_name
-            if hasattr(self._transport, "backend") and hasattr(self._transport.backend, "validate_schema"):
-                transport_config["validate_schema"] = getattr(self._transport.backend, "validate_schema", False)
-            data["transport"] = transport_config
+            data["transport"] = self._serialize_transport(self._transport)
 
         # Registry
         if self.registry_client:
-            data["registry"] = {
-                "type": getattr(self.registry_client.transport, "transport_type", "http"),
-                "url": self.registry_client.url,
-            }
+            data["registry"] = self._serialize_transport(self.registry_client.transport)
 
         # LLM
         if self.llm:
@@ -1541,43 +1556,20 @@ class AgentSerializationMixin(_AgentMixinBase):
         # Credentials
         credentials = overrides.get("credentials", data.get("credentials"))
 
-        # Transport security
-        tls = overrides.get("tls")
-        if tls is None:
-            tls_config = data.get("tls")
-            if isinstance(tls_config, dict):
-                tls = TLSConfig.from_dict(tls_config)
-
         # Transport
         transport = overrides.get("transport")
-        shared_transport_config = overrides.get("transport_config")
         if transport is None:
             transport_config = data.get("transport")
             if transport_config:
-                transport_type = transport_config.get("type", "http")
-                if shared_transport_config is None and isinstance(transport_config.get("config"), dict):
-                    shared_transport_config = TransportConfig.from_dict(transport_config["config"])
                 try:
-                    from protolink.transport import get_transport
-
-                    t_kwargs = {
-                        "url": transport_config.get("url", card_data.get("url")),
-                        "timeout": transport_config.get("timeout", 360.0),
-                    }
-                    if "backend" in transport_config:
-                        t_kwargs["backend"] = transport_config["backend"]
-                    if "validate_schema" in transport_config:
-                        t_kwargs["validate_schema"] = transport_config["validate_schema"]
-
-                    t_kwargs["authenticator"] = authenticator
-                    t_kwargs["credentials"] = credentials
-                    t_kwargs["tls"] = tls
-                    if shared_transport_config is not None:
-                        t_kwargs["config"] = shared_transport_config
-
-                    transport = get_transport(transport_type, **t_kwargs)
+                    transport = cls._deserialize_transport(
+                        transport_config,
+                        fallback_url=card_data.get("url", ""),
+                        authenticator=authenticator,
+                        credentials=credentials,
+                    )
                 except Exception:
-                    transport = transport_type
+                    transport = transport_config.get("type", "http")
 
         # Registry
         registry = overrides.get("registry")
@@ -1585,8 +1577,17 @@ class AgentSerializationMixin(_AgentMixinBase):
         if registry is None:
             registry_config = data.get("registry")
             if registry_config:
-                registry = registry_config.get("type")
                 registry_url = registry_config.get("url")
+                try:
+                    registry = RegistryClient(
+                        cls._deserialize_transport(
+                            registry_config,
+                            fallback_url=registry_url or "",
+                            credentials=credentials,
+                        )
+                    )
+                except Exception:
+                    registry = registry_config.get("type")
 
         # LLM
         llm = overrides.get("llm")
@@ -1648,8 +1649,6 @@ class AgentSerializationMixin(_AgentMixinBase):
             expose_chat=expose_chat,
             authenticator=authenticator,
             credentials=credentials,
-            tls=tls,
-            transport_config=shared_transport_config,
         )
 
         tools_data = data.get("tools", [])

--- a/protolink/client/agent.py
+++ b/protolink/client/agent.py
@@ -33,16 +33,15 @@ from protolink.models import (
     Task,
     TaskCancellationRequest,
 )
-from protolink.security.tls import TLSConfig
-from protolink.transport import Transport, TransportConfig, get_transport
+from protolink.transport import Transport, get_transport
 from protolink.types import TransportType
 
 
 class AgentClient:
     """High-level client for Agent-to-Agent and User-to-Agent communication.
 
-    This client provides a unified interface for interacting with Protolink agents over different
-    transports (HTTP, WebSocket, etc.).
+    This client provides a unified interface for interacting with Protolink agents over different transports
+    (HTTP, WebSocket, etc.).
 
     It exposes both:
     - Async API (recommended for modern applications)
@@ -154,9 +153,6 @@ class AgentClient:
         transport: Transport | TransportType,
         url: str | None = None,
         timeout: int = 300,
-        *,
-        tls: TLSConfig | None = None,
-        transport_config: TransportConfig | None = None,
     ) -> None:
         """Initialize a client from a transport instance or registered name.
 
@@ -164,20 +160,14 @@ class AgentClient:
             transport: Existing transport or registered transport name.
             url: Local transport URL required when constructing by name.
             timeout: Outbound request timeout in seconds.
-            tls: Optional TLS trust and client-certificate configuration.
-            transport_config: Shared limits, retry, keepalive, and metrics configuration.
+
+        A transport name creates a default transport for rapid prototyping. Pass a concrete transport instance to
+        configure TLS, limits, retries, keepalive, or protocol-specific behavior.
         """
         if isinstance(transport, Transport):
-            if tls is not None and getattr(transport, "tls", None) is None and hasattr(transport, "tls"):
-                setattr(transport, "tls", tls)  # noqa: B010
             self._transport = transport
         else:
-            transport_kwargs: dict[str, Any] = {"url": url, "timeout": timeout}
-            if tls is not None:
-                transport_kwargs["tls"] = tls
-            if transport_config is not None:
-                transport_kwargs["config"] = transport_config
-            self._transport = get_transport(transport=transport, **transport_kwargs)
+            self._transport = get_transport(transport=transport, url=url, timeout=timeout)
 
         self.sync = SyncAgentClient(self)
 
@@ -213,23 +203,21 @@ class AgentClient:
     async def send_task_streaming(self, agent_url: str, task: Task) -> AsyncIterator[Any]:
         """Send a task to a remote agent and receive streamed events.
 
-        This method is the high-level streaming entry point for agent-to-agent
-        communication. It delegates to the configured transport's
-        ``subscribe()`` implementation, so the same client call works with
-        streaming-capable transports such as ``"sse"``, ``"json-rpc"``,
-        ``"websocket"``, and ``"runtime"``.
+        This method is the high-level streaming entry point for agent-to-agent communication. It delegates to the
+        configured transport's ``subscribe()`` implementation, so the same client call works with streaming-capable
+        transports such as ``"sse"``, ``"json-rpc"``, ``"websocket"``, and ``"runtime"``.
 
         Args:
             agent_url: Target agent endpoint URL.
             task: Task to execute.
 
         Yields:
-            Streaming events emitted by the remote agent. Transports may yield
-            dictionaries or event objects depending on the backend.
+            Streaming events emitted by the remote agent. Transports may yield dictionaries or event objects depending
+            on the backend.
 
         Raises:
-            NotImplementedError: If the configured transport does not advertise
-                streaming support or does not implement ``subscribe()``.
+            NotImplementedError: If the configured transport does not advertise streaming support or does not implement
+            ``subscribe()``.
 
         Example:
             >>> async for event in client.send_task_streaming(url, task):
@@ -257,9 +245,8 @@ class AgentClient:
     ) -> Task:
         """Request best-effort cancellation of a task running on an agent.
 
-        The task ID is known before submission because Protolink tasks are
-        client-created. This allows a second coroutine, UI action, or control
-        request to cancel a blocking or streaming execution already in flight.
+        The task ID is known before submission because Protolink tasks are client-created. This allows a second
+        coroutine, UI action, or control request to cancel a blocking or streaming execution already in flight.
 
         Args:
             agent_url: Target agent endpoint URL.
@@ -271,8 +258,7 @@ class AgentClient:
             The remote task after the cancellation attempt is accepted.
 
         Raises:
-            RuntimeError: The remote task is unknown, terminal, or currently
-                cannot be canceled.
+            RuntimeError: The remote task is unknown, terminal, or currently cannot be canceled.
         """
         request = TaskCancellationRequest(
             id=task_id,
@@ -299,10 +285,8 @@ class AgentClient:
     ) -> HistoryCompactionResult:
         """Request LLM-history compaction from an agent control endpoint.
 
-        This uses the transport-neutral ``COMPACT_HISTORY_REQUEST`` spec and
-        calls ``POST /llm/history/compact`` on the target agent. It does not
-        send a task, does not create a model-visible tool, and does not modify
-        the LLM prompt.
+        This uses the transport-neutral ``COMPACT_HISTORY_REQUEST`` spec and calls ``POST /llm/history/compact`` on the
+        target agent. It does not send a task, does not create a model-visible tool, and does not modify the LLM prompt.
         """
         request = HistoryCompactionRequest(
             strategy=strategy,
@@ -448,8 +432,7 @@ class AgentClient:
 class SyncAgentClient:
     """Synchronous wrapper around AgentClient.
 
-    This class provides blocking equivalents of async methods
-    for use in:
+    This class provides blocking equivalents of async methods for use in:
     - scripts
     - CLI tools
     - notebooks without async support
@@ -457,8 +440,7 @@ class SyncAgentClient:
     Internally uses `asyncio.run()` to execute async operations.
 
     Warning:
-        This API should NOT be used inside an active event loop
-        (e.g., FastAPI, Jupyter async cells).
+        This API should NOT be used inside an active event loop (e.g., FastAPI, Jupyter async cells).
 
     Example:
         >>> client = AgentClient(transport="http", url="http://localhost:8000")
@@ -486,10 +468,9 @@ class SyncAgentClient:
     def send_task_streaming(self, agent_url: str, task: Task) -> Iterator[Any]:
         """Synchronously stream events from a remote agent.
 
-        This wrapper runs the async streaming API in a background thread and
-        yields events to the caller as they arrive. It is useful for scripts,
-        notebooks without an active event loop, and terminal UIs that want a
-        blocking iterator while still using Protolink's async transports.
+        This wrapper runs the async streaming API in a background thread and yields events to the caller as they arrive.
+        It is useful for scripts, notebooks without an active event loop, and terminal UIs that want a blocking iterator
+        while still using Protolink's async transports.
 
         Example:
             >>> for event in client.sync.send_task_streaming(url, task):

--- a/protolink/client/agent.py
+++ b/protolink/client/agent.py
@@ -34,7 +34,7 @@ from protolink.models import (
     TaskCancellationRequest,
 )
 from protolink.security.tls import TLSConfig
-from protolink.transport import Transport, get_transport
+from protolink.transport import Transport, TransportConfig, get_transport
 from protolink.types import TransportType
 
 
@@ -83,6 +83,7 @@ class AgentClient:
         method="POST",
         response_parser=Task.from_dict,
         request_source="body",
+        idempotent=True,
     )
 
     AGENT_CARD_REQUEST = ClientRequestSpec(
@@ -91,6 +92,7 @@ class AgentClient:
         method="GET",
         response_parser=AgentCard.from_dict,
         request_source="none",
+        idempotent=True,
     )
 
     TASK_STREAM_REQUEST = ClientRequestSpec(
@@ -107,6 +109,7 @@ class AgentClient:
         response_parser=Task.from_dict,
         request_source="body",
         channel="control",
+        idempotent=True,
     )
 
     COMPACT_HISTORY_REQUEST = ClientRequestSpec(
@@ -125,6 +128,7 @@ class AgentClient:
         response_parser=StateOperationResult.from_dict,
         request_source="body",
         channel="control",
+        idempotent=True,
     )
 
     RESET_STATE_REQUEST = ClientRequestSpec(
@@ -152,6 +156,7 @@ class AgentClient:
         timeout: int = 300,
         *,
         tls: TLSConfig | None = None,
+        transport_config: TransportConfig | None = None,
     ) -> None:
         """Initialize a client from a transport instance or registered name.
 
@@ -160,6 +165,7 @@ class AgentClient:
             url: Local transport URL required when constructing by name.
             timeout: Outbound request timeout in seconds.
             tls: Optional TLS trust and client-certificate configuration.
+            transport_config: Shared limits, retry, keepalive, and metrics configuration.
         """
         if isinstance(transport, Transport):
             if tls is not None and getattr(transport, "tls", None) is None and hasattr(transport, "tls"):
@@ -169,9 +175,16 @@ class AgentClient:
             transport_kwargs: dict[str, Any] = {"url": url, "timeout": timeout}
             if tls is not None:
                 transport_kwargs["tls"] = tls
+            if transport_config is not None:
+                transport_kwargs["config"] = transport_config
             self._transport = get_transport(transport=transport, **transport_kwargs)
 
         self.sync = SyncAgentClient(self)
+
+    @property
+    def transport(self) -> Transport:
+        """Return the transport used for all client requests."""
+        return self._transport
 
     # ----------------------------------------------------------------------
     # Agent-to-Agent Communication

--- a/protolink/client/registry.py
+++ b/protolink/client/registry.py
@@ -1,3 +1,5 @@
+"""Transport-neutral client operations for the ProtoLink Agent Registry."""
+
 from typing import Any
 
 from protolink.client.request_spec import ClientRequestSpec
@@ -10,6 +12,16 @@ from protolink.transport import Transport
 
 
 class RegistryClient:
+    """Call Registry endpoints through an already configured transport.
+
+    The transport owns its URL, TLS, authentication, limits, and retry policy.
+    Registry operations declare idempotency individually so transports can
+    retry only those calls whose semantics are safe to repeat.
+
+    Args:
+        transport: Concrete transport used for every Registry request.
+    """
+
     REGISTER_REQUEST = ClientRequestSpec(
         name="register",
         path="/agents/",
@@ -42,6 +54,7 @@ class RegistryClient:
     )
 
     def __init__(self, transport: Transport):
+        """Store the concrete Registry transport without modifying it."""
         self.transport = transport
 
     async def register(self, card: AgentCard) -> dict[str, str]:
@@ -60,6 +73,14 @@ class RegistryClient:
         return response
 
     async def unregister(self, agent_url: str) -> dict[str, str]:
+        """Remove an agent registration by its stable URL.
+
+        Args:
+            agent_url: URL that identifies the registered agent.
+
+        Returns:
+            Registry status payload.
+        """
         response = await self.transport.send(
             request_spec=self.UNREGISTER_REQUEST, base_url=self.transport.url, data={"agent_url": agent_url}
         )
@@ -82,6 +103,14 @@ class RegistryClient:
         return response
 
     async def discover(self, filter_by: dict[str, Any] | None = None) -> list[AgentCard]:
+        """Discover Agent cards matching optional Registry filters.
+
+        Args:
+            filter_by: Optional name, role, tag, or other supported filters.
+
+        Returns:
+            Agent cards reconstructed from the Registry response.
+        """
         response = await self.transport.send(
             request_spec=self.DISCOVER_REQUEST, base_url=self.transport.url, data=filter_by
         )
@@ -89,4 +118,5 @@ class RegistryClient:
 
     @property
     def url(self) -> str:
+        """Return the Registry URL owned by the configured transport."""
         return self.transport.url

--- a/protolink/client/registry.py
+++ b/protolink/client/registry.py
@@ -22,6 +22,7 @@ class RegistryClient:
         path="/agents/",
         method="DELETE",
         request_source="body",
+        idempotent=True,
     )
 
     HEARTBEAT_REQUEST = ClientRequestSpec(
@@ -29,6 +30,7 @@ class RegistryClient:
         path="/agents/heartbeat",
         method="POST",
         request_source="body",
+        idempotent=True,
     )
 
     DISCOVER_REQUEST = ClientRequestSpec(
@@ -36,6 +38,7 @@ class RegistryClient:
         path="/agents/",
         method="GET",
         request_source="query_params",
+        idempotent=True,
     )
 
     def __init__(self, transport: Transport):

--- a/protolink/client/request_spec.py
+++ b/protolink/client/request_spec.py
@@ -1,3 +1,5 @@
+"""Transport-neutral declarations for outbound ProtoLink operations."""
+
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
@@ -13,6 +15,19 @@ class ClientRequestSpec:
     as cancellation from a long-lived streaming data channel. Request/response
     transports may ignore it. ``idempotent`` is an explicit safety declaration:
     configured retry policies never retry a request unless it is true.
+
+    Args:
+        name: Stable operation name used by clients and diagnostics.
+        path: Transport-neutral endpoint path.
+        method: HTTP-style method used consistently across transports.
+        response_parser: Optional conversion from wire data to a domain model.
+        request_source: Whether input is sent as a body, query parameters, or
+            omitted.
+        content_type: Optional request media type.
+        accept: Optional expected response media type.
+        channel: Multiplexing channel used to isolate concurrent traffic.
+        idempotent: Whether retries and server-side response deduplication are
+            safe for this operation.
     """
 
     name: str

--- a/protolink/client/request_spec.py
+++ b/protolink/client/request_spec.py
@@ -11,7 +11,8 @@ class ClientRequestSpec:
 
     ``channel`` lets multiplexed transports isolate control-plane requests such
     as cancellation from a long-lived streaming data channel. Request/response
-    transports may ignore it.
+    transports may ignore it. ``idempotent`` is an explicit safety declaration:
+    configured retry policies never retry a request unless it is true.
     """
 
     name: str
@@ -22,3 +23,4 @@ class ClientRequestSpec:
     content_type: ContentType | None = None
     accept: ContentType | None = None
     channel: str = "default"
+    idempotent: bool = False

--- a/protolink/core/agent_card.py
+++ b/protolink/core/agent_card.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections.abc import Mapping
 from dataclasses import asdict, dataclass, field
 from typing import Any, final
@@ -89,6 +91,42 @@ class AgentSkill:
             self.output_schema = {}
 
 
+@dataclass(frozen=True, slots=True)
+class AgentInterface:
+    """Describe an additional endpoint exposed by an agent.
+
+    ``AgentCard.url`` and ``AgentCard.transport`` remain the primary interface.
+    Use this type only when the same agent is reachable through more than one
+    transport, such as HTTP for broad compatibility and gRPC for internal calls.
+
+    Args:
+        url: Absolute endpoint URL.
+        transport: Registered ProtoLink transport name.
+        protocol_version: Protocol version served by this endpoint.
+    """
+
+    url: str
+    transport: TransportType
+    protocol_version: str = protolink_version
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> AgentInterface:
+        """Create an interface from serialized card data."""
+        return cls(
+            url=str(data["url"]),
+            transport=data.get("transport", "http"),
+            protocol_version=str(data.get("protocolVersion", protolink_version)),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the interface in AgentCard wire format."""
+        return {
+            "url": self.url,
+            "transport": self.transport,
+            "protocolVersion": self.protocol_version,
+        }
+
+
 @final
 @dataclass
 class AgentCard:
@@ -109,6 +147,7 @@ class AgentCard:
         tags: List of tags for categorization. These tags can be used for filtering
             during discovery (Protolink extension to A2A spec) [Optional]
             E.g. "finance", "travel", "math" etc.
+        interfaces: Optional additional endpoints for this same agent identity.
     """
 
     name: str
@@ -124,6 +163,7 @@ class AgentCard:
     security_schemes: dict[SecuritySchemeType, dict[str, Any]] | None = field(default_factory=dict)
     role: AgentRoleType = "worker"
     tags: list[str] = field(default_factory=list)
+    interfaces: list[AgentInterface] = field(default_factory=list)
 
     def __post_init__(self):
         """Normalize fields after initialization."""
@@ -131,13 +171,19 @@ class AgentCard:
         capabilities: Any = self.capabilities
         if isinstance(capabilities, Mapping):
             self.capabilities = AgentCapabilities(**dict(capabilities))
-            return
-        if not isinstance(capabilities, AgentCapabilities):
+        elif not isinstance(capabilities, AgentCapabilities):
             raise TypeError(f"capabilities must be AgentCapabilities or mapping, got {type(capabilities).__name__}")
+        raw_interfaces: list[Any] = list(self.interfaces)
+        self.interfaces = [
+            AgentInterface.from_dict(interface) if isinstance(interface, Mapping) else interface
+            for interface in raw_interfaces
+        ]
+        if not all(isinstance(interface, AgentInterface) for interface in self.interfaces):
+            raise TypeError("interfaces must contain AgentInterface instances or mappings")
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to JSON format (A2A agent card spec)."""
-        return {
+        data = {
             "name": self.name,
             "description": self.description,
             "url": self.url,
@@ -151,9 +197,12 @@ class AgentCard:
             "securitySchemes": self.security_schemes,
             "tags": self.tags,
         }
+        if self.interfaces:
+            data["additionalInterfaces"] = [interface.to_dict() for interface in self.interfaces]
+        return data
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> "AgentCard":
+    def from_dict(cls, data: dict[str, Any]) -> AgentCard:
         """Create from Python dict/JSON data."""
 
         cls._validate_fields(data)
@@ -175,6 +224,7 @@ class AgentCard:
             output_formats=data.get("outputFormats", ["text/plain"]),
             security_schemes=data.get("securitySchemes", {}),
             tags=data.get("tags", []),
+            interfaces=data.get("interfaces", data.get("additionalInterfaces", [])),
         )
 
     @staticmethod

--- a/protolink/devtools/doctor.py
+++ b/protolink/devtools/doctor.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import sqlite3
+from contextlib import closing
 from pathlib import Path
 from typing import Any
 from urllib.error import URLError
@@ -78,7 +79,7 @@ def _check_run_store(path: Path) -> CheckResult:
         return CheckResult("run store", "warn", f"{path} does not exist yet")
 
     try:
-        with sqlite3.connect(str(path)) as conn:
+        with closing(sqlite3.connect(str(path))) as conn:
             rows = conn.execute(
                 "SELECT name FROM sqlite_master WHERE type = 'table' AND (name LIKE '%run%' OR name LIKE '%task%')"
             ).fetchall()

--- a/protolink/discovery/registry.py
+++ b/protolink/discovery/registry.py
@@ -16,7 +16,7 @@ from protolink.models import AgentCard
 from protolink.security.tls import TLSConfig
 from protolink.server import RegistryServer
 from protolink.storage import Storage
-from protolink.transport import Transport, get_transport
+from protolink.transport import Transport, TransportConfig, get_transport
 from protolink.types import TransportType
 from protolink.utils.logging import get_logger
 from protolink.utils.renderers.status import to_registry_status_html
@@ -52,6 +52,7 @@ class Registry:
         entry_ttl_seconds: float | None = None,
         storage: Storage | None = None,
         tls: TLSConfig | None = None,
+        transport_config: TransportConfig | None = None,
     ):
         """Initialize the registry.
 
@@ -64,6 +65,7 @@ class Registry:
             storage: Optional generic storage used to persist registry entries
                 across process restarts.
             tls: Optional transport-security configuration for secure registry URLs.
+            transport_config: Shared limits, retry, keepalive, and metrics configuration.
         """
         self.logger = get_logger(__name__, verbosity)
 
@@ -74,6 +76,8 @@ class Registry:
             transport_kwargs: dict[str, Any] = {"url": url}
             if tls is not None:
                 transport_kwargs["tls"] = tls
+            if transport_config is not None:
+                transport_kwargs["config"] = transport_config
             transport = get_transport(transport, **transport_kwargs)
         elif not isinstance(transport, Transport):
             raise ValueError("transport must be a TransportType or Transport instance")

--- a/protolink/discovery/registry.py
+++ b/protolink/discovery/registry.py
@@ -13,10 +13,9 @@ from typing import Any, Literal
 from protolink.client import RegistryClient
 from protolink.core.registry import RegistryEntry
 from protolink.models import AgentCard
-from protolink.security.tls import TLSConfig
 from protolink.server import RegistryServer
 from protolink.storage import Storage
-from protolink.transport import Transport, TransportConfig, get_transport
+from protolink.transport import Transport, get_transport
 from protolink.types import TransportType
 from protolink.utils.logging import get_logger
 from protolink.utils.renderers.status import to_registry_status_html
@@ -51,8 +50,6 @@ class Registry:
         *,
         entry_ttl_seconds: float | None = None,
         storage: Storage | None = None,
-        tls: TLSConfig | None = None,
-        transport_config: TransportConfig | None = None,
     ):
         """Initialize the registry.
 
@@ -64,8 +61,10 @@ class Registry:
                 is older than this value are pruned before discovery/status.
             storage: Optional generic storage used to persist registry entries
                 across process restarts.
-            tls: Optional transport-security configuration for secure registry URLs.
-            transport_config: Shared limits, retry, keepalive, and metrics configuration.
+
+        A transport name creates a default transport for rapid prototyping.
+        Pass a concrete transport instance to configure TLS, limits, retries,
+        keepalive, or protocol-specific behavior.
         """
         self.logger = get_logger(__name__, verbosity)
 
@@ -73,16 +72,9 @@ class Registry:
         if isinstance(transport, str):
             if url is None:
                 raise ValueError("url must be provided if transport is a TransportType")
-            transport_kwargs: dict[str, Any] = {"url": url}
-            if tls is not None:
-                transport_kwargs["tls"] = tls
-            if transport_config is not None:
-                transport_kwargs["config"] = transport_config
-            transport = get_transport(transport, **transport_kwargs)
+            transport = get_transport(transport, url=url)
         elif not isinstance(transport, Transport):
             raise ValueError("transport must be a TransportType or Transport instance")
-        elif tls is not None and getattr(transport, "tls", None) is None and hasattr(transport, "tls"):
-            setattr(transport, "tls", tls)  # noqa: B010
 
         # Local store for agent cards. ``_agents`` remains public-ish for
         # compatibility with tests and examples; ``_entries`` carries liveness

--- a/protolink/models/__init__.py
+++ b/protolink/models/__init__.py
@@ -1,6 +1,6 @@
 from protolink.client.request_spec import ClientRequestSpec
 from protolink.core.actions import RunAction
-from protolink.core.agent_card import AgentCard, AgentSkill
+from protolink.core.agent_card import AgentCard, AgentInterface, AgentSkill
 from protolink.core.artifact import Artifact
 from protolink.core.cancellation import TaskCancellationRequest
 from protolink.core.events import EventSink, InMemoryEventSink, RunEvent
@@ -15,6 +15,7 @@ from protolink.state.operations import StateOperationRequest, StateOperationResu
 
 __all__ = [
     "AgentCard",
+    "AgentInterface",
     "AgentSkill",
     "Artifact",
     "ClientRequestSpec",

--- a/protolink/models/__init__.py
+++ b/protolink/models/__init__.py
@@ -1,3 +1,5 @@
+"""Public protocol models and transport-neutral request specifications."""
+
 from protolink.client.request_spec import ClientRequestSpec
 from protolink.core.actions import RunAction
 from protolink.core.agent_card import AgentCard, AgentInterface, AgentSkill

--- a/protolink/server/agent.py
+++ b/protolink/server/agent.py
@@ -173,6 +173,20 @@ class AgentServer:
                 content_type="html",
             ),
             EndpointSpec(
+                name="health",
+                path="/healthz",
+                method="GET",
+                handler=self._transport.health,
+                request_source="none",
+            ),
+            EndpointSpec(
+                name="readiness",
+                path="/readyz",
+                method="GET",
+                handler=self._transport.health,
+                request_source="none",
+            ),
+            EndpointSpec(
                 name="chat_page",
                 path="/chat",
                 method="GET",

--- a/protolink/server/registry.py
+++ b/protolink/server/registry.py
@@ -116,6 +116,20 @@ class RegistryServer:
                     request_source="none",
                     content_type="html",
                 ),
+                EndpointSpec(
+                    name="health",
+                    path="/healthz",
+                    method="GET",
+                    handler=self._transport.health,
+                    request_source="none",
+                ),
+                EndpointSpec(
+                    name="readiness",
+                    path="/readyz",
+                    method="GET",
+                    handler=self._transport.health,
+                    request_source="none",
+                ),
             ]
         )
 

--- a/protolink/storage/run_store.py
+++ b/protolink/storage/run_store.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
+from contextlib import closing
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Protocol
@@ -186,7 +187,7 @@ class SQLiteRunStore:
 
     def _init_db(self) -> None:
         """Create storage tables and indexes when missing."""
-        with self._connect() as conn:
+        with closing(self._connect()) as conn:
             conn.execute(
                 f"""
                 CREATE TABLE IF NOT EXISTS {self.tasks_table} (
@@ -250,7 +251,7 @@ class SQLiteRunStore:
             created_at=task.created_at,
             updated_at=utc_now(),
         )
-        with self._connect() as conn:
+        with closing(self._connect()) as conn:
             conn.execute(
                 f"""
                 INSERT OR REPLACE INTO {self.tasks_table}
@@ -281,7 +282,7 @@ class SQLiteRunStore:
 
     def get_task_record(self, task_id: str) -> TaskRecord | None:
         """Load one task record by task ID."""
-        with self._connect() as conn:
+        with closing(self._connect()) as conn:
             row = conn.execute(f"SELECT * FROM {self.tasks_table} WHERE task_id = ?", (task_id,)).fetchone()
         return _task_record_from_row(row) if row else None
 
@@ -312,7 +313,7 @@ class SQLiteRunStore:
 
         where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
         values.append(limit)
-        with self._connect() as conn:
+        with closing(self._connect()) as conn:
             rows = conn.execute(
                 f"SELECT * FROM {self.tasks_table} {where} ORDER BY updated_at DESC LIMIT ?",
                 tuple(values),
@@ -343,7 +344,7 @@ class SQLiteRunStore:
             metadata=dict(metadata or {}),
             created_at=utc_now(),
         )
-        with self._connect() as conn:
+        with closing(self._connect()) as conn:
             conn.execute(
                 f"""
                 INSERT OR REPLACE INTO {self.reports_table}
@@ -370,7 +371,7 @@ class SQLiteRunStore:
 
     def get_report_record(self, run_id: str) -> RunReportRecord | None:
         """Load one run report record by run ID."""
-        with self._connect() as conn:
+        with closing(self._connect()) as conn:
             row = conn.execute(f"SELECT * FROM {self.reports_table} WHERE run_id = ?", (run_id,)).fetchone()
         return _report_record_from_row(row) if row else None
 
@@ -392,7 +393,7 @@ class SQLiteRunStore:
             values.append(agent_name)
         where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
         values.append(limit)
-        with self._connect() as conn:
+        with closing(self._connect()) as conn:
             rows = conn.execute(
                 f"SELECT * FROM {self.reports_table} {where} ORDER BY created_at DESC LIMIT ?",
                 tuple(values),
@@ -401,13 +402,13 @@ class SQLiteRunStore:
 
     def delete_task(self, task_id: str) -> None:
         """Delete one task snapshot by task ID."""
-        with self._connect() as conn:
+        with closing(self._connect()) as conn:
             conn.execute(f"DELETE FROM {self.tasks_table} WHERE task_id = ?", (task_id,))
             conn.commit()
 
     def delete_report(self, run_id: str) -> None:
         """Delete one run report by run ID."""
-        with self._connect() as conn:
+        with closing(self._connect()) as conn:
             conn.execute(f"DELETE FROM {self.reports_table} WHERE run_id = ?", (run_id,))
             conn.commit()
 

--- a/protolink/storage/sqlite.py
+++ b/protolink/storage/sqlite.py
@@ -2,6 +2,7 @@
 
 import json
 import sqlite3
+from contextlib import closing
 from typing import Any
 
 from protolink.storage.base import Storage
@@ -38,7 +39,7 @@ class SQLiteStorage(Storage):
 
     def _init_db(self) -> None:
         """Initializes the database schema."""
-        with sqlite3.connect(self.db_path) as conn:
+        with closing(sqlite3.connect(self.db_path)) as conn:
             conn.execute(
                 f"""
                 CREATE TABLE IF NOT EXISTS {self.table_name} (
@@ -55,7 +56,7 @@ class SQLiteStorage(Storage):
         Data is serialized to JSON before storage.
         """
         serialized_data = json.dumps(data)
-        with sqlite3.connect(self.db_path) as conn:
+        with closing(sqlite3.connect(self.db_path)) as conn:
             conn.execute(
                 f"INSERT OR REPLACE INTO {self.table_name} (key, value) VALUES (?, ?)",
                 (self.namespace, serialized_data),
@@ -68,7 +69,7 @@ class SQLiteStorage(Storage):
         Returns:
             The loaded data deserialized from JSON, or None if not found.
         """
-        with sqlite3.connect(self.db_path) as conn:
+        with closing(sqlite3.connect(self.db_path)) as conn:
             cursor = conn.execute(f"SELECT value FROM {self.table_name} WHERE key = ?", (self.namespace,))
             row = cursor.fetchone()
             if row:
@@ -84,6 +85,6 @@ class SQLiteStorage(Storage):
 
     def delete(self) -> None:
         """Deletes the data from the storage."""
-        with sqlite3.connect(self.db_path) as conn:
+        with closing(sqlite3.connect(self.db_path)) as conn:
             conn.execute(f"DELETE FROM {self.table_name} WHERE key = ?", (self.namespace,))
             conn.commit()

--- a/protolink/transport/__init__.py
+++ b/protolink/transport/__init__.py
@@ -3,15 +3,37 @@ from __future__ import annotations
 import importlib
 from typing import Any
 
-from .base import Transport
+from .base import Transport, TransportRequestContext
+from .config import RetryPolicy, TransportCapabilities, TransportConfig, TransportLimits
+from .errors import (
+    TransportConnectionError,
+    TransportError,
+    TransportLimitError,
+    TransportProtocolError,
+    TransportRemoteError,
+    TransportTimeoutError,
+)
 from .factory import get_transport
+from .metrics import TransportMetricsSnapshot
 
 __all__ = [
     "GRPCTransport",
     "HTTPTransport",
+    "RetryPolicy",
     "RuntimeTransport",
     "SSEJSONRPCTransport",
     "Transport",
+    "TransportCapabilities",
+    "TransportConfig",
+    "TransportConnectionError",
+    "TransportError",
+    "TransportLimitError",
+    "TransportLimits",
+    "TransportMetricsSnapshot",
+    "TransportProtocolError",
+    "TransportRemoteError",
+    "TransportRequestContext",
+    "TransportTimeoutError",
     "WebSocketTransport",
     "get_transport",
 ]

--- a/protolink/transport/backends/base.py
+++ b/protolink/transport/backends/base.py
@@ -12,11 +12,17 @@ from protolink.utils.serialization import Serializer
 if TYPE_CHECKING:
     from protolink.security.auth import Authenticator
     from protolink.security.tls import TLSConfig
+    from protolink.transport.base import Transport
 
 
 class BackendInterface(ABC):
     @abstractmethod
-    def setup_routes(self, endpoints: list[EndpointSpec], authenticator: Authenticator | None = None) -> None:
+    def setup_routes(
+        self,
+        endpoints: list[EndpointSpec],
+        authenticator: Authenticator | None = None,
+        transport: Transport | None = None,
+    ) -> None:
         """Register all abstract endpoints onto the physical ASGI routing table.
 
         Subclasses must implement this to iterate over the provided `EndpointSpec` models

--- a/protolink/transport/backends/fastapi.py
+++ b/protolink/transport/backends/fastapi.py
@@ -126,7 +126,13 @@ class FastAPIBackend(BackendInterface):
             handler_is_async = is_async_callable(ep.handler)
 
             try:
-                if ep.request_source != "none":
+                if transport is not None:
+                    async with transport.inbound_request_slot():
+                        if ep.request_source != "none":
+                            result = await ep.handler(handler_input) if handler_is_async else ep.handler(handler_input)
+                        else:
+                            result = await ep.handler() if handler_is_async else ep.handler()
+                elif ep.request_source != "none":
                     result = await ep.handler(handler_input) if handler_is_async else ep.handler(handler_input)
                 else:
                     result = await ep.handler() if handler_is_async else ep.handler()
@@ -172,39 +178,25 @@ class FastAPIBackend(BackendInterface):
         HTTP clients can consume the same task stream shape as WebSocket clients.
         """
         try:
-            if ep.request_source != "none" and payload is not None:
-                stream_obj = ep.handler(handler_input)
+            if transport is not None:
+                async with transport.stream_slot():
+                    async for frame in self._iter_sse_frames(
+                        ep=ep,
+                        handler_input=handler_input,
+                        payload=payload,
+                        request_id=request_id,
+                        transport=transport,
+                    ):
+                        yield frame
             else:
-                stream_obj = ep.handler()
-
-            if inspect.isawaitable(stream_obj):
-                stream_obj = await stream_obj
-
-            if not hasattr(stream_obj, "__aiter__"):
-                raise TypeError("Streaming endpoint handler must return an async iterator")
-
-            sent_final = False
-            async for event in stream_obj:
-                event_payload = self._serialize_result(event)
-                if transport is not None:
-                    transport.check_payload_limit(event_payload, kind="event")
-                event_final = bool(event_payload.get("final", False)) if isinstance(event_payload, dict) else False
-                stream_final = is_stream_terminal_event(event_payload, event_final=event_final)
-                yield self._sse_frame(
-                    {
-                        "jsonrpc": "2.0",
-                        "id": request_id,
-                        "ok": True,
-                        "result": event_payload,
-                        "final": stream_final,
-                    }
-                )
-                if stream_final:
-                    sent_final = True
-                    break
-
-            if not sent_final:
-                yield self._sse_frame({"jsonrpc": "2.0", "id": request_id, "ok": True, "result": None, "final": True})
+                async for frame in self._iter_sse_frames(
+                    ep=ep,
+                    handler_input=handler_input,
+                    payload=payload,
+                    request_id=request_id,
+                    transport=None,
+                ):
+                    yield frame
         except Exception as exc:
             yield self._sse_frame(
                 {
@@ -215,6 +207,49 @@ class FastAPIBackend(BackendInterface):
                     "final": True,
                 }
             )
+
+    async def _iter_sse_frames(
+        self,
+        *,
+        ep: EndpointSpec,
+        handler_input: Any,
+        payload: Any,
+        request_id: str | None,
+        transport: "Transport | None",
+    ):
+        """Execute one SSE handler and yield successful protocol frames."""
+        if ep.request_source != "none" and payload is not None:
+            stream_obj = ep.handler(handler_input)
+        else:
+            stream_obj = ep.handler()
+
+        if inspect.isawaitable(stream_obj):
+            stream_obj = await stream_obj
+        if not hasattr(stream_obj, "__aiter__"):
+            raise TypeError("Streaming endpoint handler must return an async iterator")
+
+        sent_final = False
+        async for event in stream_obj:
+            event_payload = self._serialize_result(event)
+            if transport is not None:
+                transport.check_payload_limit(event_payload, kind="event")
+            event_final = bool(event_payload.get("final", False)) if isinstance(event_payload, dict) else False
+            stream_final = is_stream_terminal_event(event_payload, event_final=event_final)
+            yield self._sse_frame(
+                {
+                    "jsonrpc": "2.0",
+                    "id": request_id,
+                    "ok": True,
+                    "result": event_payload,
+                    "final": stream_final,
+                }
+            )
+            if stream_final:
+                sent_final = True
+                break
+
+        if not sent_final:
+            yield self._sse_frame({"jsonrpc": "2.0", "id": request_id, "ok": True, "result": None, "final": True})
 
     def _sse_frame(self, payload: dict[str, Any]) -> str:
         """Serialize a JSON payload as a single Server-Sent Event frame."""

--- a/protolink/transport/backends/fastapi.py
+++ b/protolink/transport/backends/fastapi.py
@@ -8,7 +8,7 @@ FastAPI routes, optionally leveraging Pydantic schema generation.
 import asyncio
 import inspect
 import json
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from protolink.security.tls import TLSConfig
 from protolink.server.endpoint_handler import EndpointSpec
@@ -17,9 +17,20 @@ from protolink.transport._streaming import is_stream_terminal_event
 from protolink.transport.backends.base import BackendInterface
 from protolink.utils.inspect import is_async_callable
 
+if TYPE_CHECKING:
+    from protolink.transport.base import Transport
+
 
 class FastAPIBackend(BackendInterface):
-    def __init__(self, *, validate_schema: bool = False, log_level: str = "info", access_log: bool = True) -> None:
+    def __init__(
+        self,
+        *,
+        validate_schema: bool = False,
+        log_level: str = "info",
+        access_log: bool = True,
+        keepalive_timeout: float = 20.0,
+        limit_concurrency: int = 100,
+    ) -> None:
         FastAPI, _, _, _, _, _ = _require_fastapi(validate_schema=validate_schema)  # noqa: N806
 
         self.app = FastAPI()
@@ -27,19 +38,26 @@ class FastAPIBackend(BackendInterface):
         self._server_instance: Any = None
         self._log_level = log_level
         self._access_log = access_log
+        self._keepalive_timeout = keepalive_timeout
+        self._limit_concurrency = limit_concurrency
 
     # ----------------------------------------------------------------------
     # Setup Routes - Define Server URIs
     # ----------------------------------------------------------------------
 
-    def _register_endpoint(self, ep: EndpointSpec, authenticator: Any = None) -> None:
+    def _register_endpoint(
+        self,
+        ep: EndpointSpec,
+        authenticator: Any = None,
+        transport: "Transport | None" = None,
+    ) -> None:
         _, Request, JSONResponse, HTMLResponse, StreamingResponse, _ = _require_fastapi()  # noqa: N806
 
         async def route(request: Request):
             # -------------------------
             # Authenticate request
             # -------------------------
-            if authenticator:
+            if authenticator and ep.path not in {"/healthz", "/readyz"}:
                 from protolink.security.auth import extract_credentials
 
                 credentials = extract_credentials(request.headers, dict(request.query_params))
@@ -63,6 +81,9 @@ class FastAPIBackend(BackendInterface):
             else:
                 payload = None
 
+            if transport is not None:
+                transport.check_payload_limit(payload, kind="request", url=str(request.url))
+
             # -------------------------
             # Parse payload
             # -------------------------
@@ -83,19 +104,36 @@ class FastAPIBackend(BackendInterface):
                         handler_input=handler_input,
                         payload=payload,
                         request_id=request_id,
+                        transport=transport,
                     ),
                     media_type="text/event-stream",
+                    headers={"X-Protolink-Request-ID": request_id or ""},
                 )
+
+            raw_idempotency_key = request.headers.get("idempotency-key")
+            idempotency_key = f"{ep.method}:{ep.path}:{raw_idempotency_key}" if raw_idempotency_key else None
+            if transport is not None:
+                owns_operation, cached = await transport.acquire_idempotent_response(idempotency_key)
+                if not owns_operation:
+                    return JSONResponse(
+                        content=cached,
+                        headers={"X-Protolink-Request-ID": request.headers.get("x-protolink-request-id", "")},
+                    )
 
             # -------------------------
             # Call handler
             # -------------------------
             handler_is_async = is_async_callable(ep.handler)
 
-            if ep.request_source != "none":
-                result = await ep.handler(handler_input) if handler_is_async else ep.handler(handler_input)
-            else:
-                result = await ep.handler() if handler_is_async else ep.handler()
+            try:
+                if ep.request_source != "none":
+                    result = await ep.handler(handler_input) if handler_is_async else ep.handler(handler_input)
+                else:
+                    result = await ep.handler() if handler_is_async else ep.handler()
+            except BaseException as exc:
+                if transport is not None:
+                    transport.abort_idempotent_response(idempotency_key, exc)
+                raise
 
             # -------------------------
             # Response
@@ -104,7 +142,13 @@ class FastAPIBackend(BackendInterface):
                 return HTMLResponse(content=result)
 
             serialized_result = self._serialize_result(result)
-            return JSONResponse(content=serialized_result)
+            if transport is not None:
+                transport.check_payload_limit(serialized_result, kind="response", url=str(request.url))
+                transport.complete_idempotent_response(idempotency_key, serialized_result)
+            return JSONResponse(
+                content=serialized_result,
+                headers={"X-Protolink-Request-ID": request.headers.get("x-protolink-request-id", "")},
+            )
 
         self.app.add_api_route(
             ep.path,
@@ -112,7 +156,15 @@ class FastAPIBackend(BackendInterface):
             methods=[ep.method],
         )
 
-    async def _stream_sse(self, *, ep: EndpointSpec, handler_input: Any, payload: Any, request_id: str | None):
+    async def _stream_sse(
+        self,
+        *,
+        ep: EndpointSpec,
+        handler_input: Any,
+        payload: Any,
+        request_id: str | None,
+        transport: "Transport | None" = None,
+    ):
         """Yield JSON-RPC envelopes as Server-Sent Events.
 
         Streaming endpoint handlers return async iterators of Protolink events.
@@ -134,6 +186,8 @@ class FastAPIBackend(BackendInterface):
             sent_final = False
             async for event in stream_obj:
                 event_payload = self._serialize_result(event)
+                if transport is not None:
+                    transport.check_payload_limit(event_payload, kind="event")
                 event_final = bool(event_payload.get("final", False)) if isinstance(event_payload, dict) else False
                 stream_final = is_stream_terminal_event(event_payload, event_final=event_final)
                 yield self._sse_frame(
@@ -166,7 +220,12 @@ class FastAPIBackend(BackendInterface):
         """Serialize a JSON payload as a single Server-Sent Event frame."""
         return f"data: {json.dumps(payload)}\n\n"
 
-    def setup_routes(self, endpoints: list[EndpointSpec], authenticator: Any = None) -> None:
+    def setup_routes(
+        self,
+        endpoints: list[EndpointSpec],
+        authenticator: Any = None,
+        transport: "Transport | None" = None,
+    ) -> None:
         """Mount abstract Protolink endpoints as physical FastAPI routes.
 
         This method acts as the architectural bridge between Protolink's internal `EndpointSpec`
@@ -175,7 +234,7 @@ class FastAPIBackend(BackendInterface):
         marshaling the result back over the wire via FastAPI's `JSONResponse`.
         """
         for ep in endpoints:
-            self._register_endpoint(ep, authenticator=authenticator)
+            self._register_endpoint(ep, authenticator=authenticator, transport=transport)
 
     # ----------------------------------------------------------------------
     # ASGI Server Lifecycle
@@ -201,6 +260,8 @@ class FastAPIBackend(BackendInterface):
             port=port,
             log_level=self._log_level,
             access_log=self._access_log,
+            limit_concurrency=self._limit_concurrency,
+            timeout_keep_alive=int(self._keepalive_timeout),
             **self._uvicorn_tls_kwargs(url, tls),
         )
         server = uvicorn.Server(config)

--- a/protolink/transport/backends/starlette.py
+++ b/protolink/transport/backends/starlette.py
@@ -125,7 +125,13 @@ class StarletteBackend(BackendInterface):
             handler_is_async = is_async_callable(ep.handler)
 
             try:
-                if ep.request_source != "none" and payload is not None:
+                if transport is not None:
+                    async with transport.inbound_request_slot():
+                        if ep.request_source != "none" and payload is not None:
+                            result = await ep.handler(handler_input) if handler_is_async else ep.handler(handler_input)
+                        else:
+                            result = await ep.handler() if handler_is_async else ep.handler()
+                elif ep.request_source != "none" and payload is not None:
                     result = await ep.handler(handler_input) if handler_is_async else ep.handler(handler_input)
                 else:
                     result = await ep.handler() if handler_is_async else ep.handler()
@@ -167,39 +173,25 @@ class StarletteBackend(BackendInterface):
         HTTP clients can consume the same task stream shape as WebSocket clients.
         """
         try:
-            if ep.request_source != "none" and payload is not None:
-                stream_obj = ep.handler(handler_input)
+            if transport is not None:
+                async with transport.stream_slot():
+                    async for frame in self._iter_sse_frames(
+                        ep=ep,
+                        handler_input=handler_input,
+                        payload=payload,
+                        request_id=request_id,
+                        transport=transport,
+                    ):
+                        yield frame
             else:
-                stream_obj = ep.handler()
-
-            if inspect.isawaitable(stream_obj):
-                stream_obj = await stream_obj
-
-            if not hasattr(stream_obj, "__aiter__"):
-                raise TypeError("Streaming endpoint handler must return an async iterator")
-
-            sent_final = False
-            async for event in stream_obj:
-                event_payload = self._serialize_result(event)
-                if transport is not None:
-                    transport.check_payload_limit(event_payload, kind="event")
-                event_final = bool(event_payload.get("final", False)) if isinstance(event_payload, dict) else False
-                stream_final = is_stream_terminal_event(event_payload, event_final=event_final)
-                yield self._sse_frame(
-                    {
-                        "jsonrpc": "2.0",
-                        "id": request_id,
-                        "ok": True,
-                        "result": event_payload,
-                        "final": stream_final,
-                    }
-                )
-                if stream_final:
-                    sent_final = True
-                    break
-
-            if not sent_final:
-                yield self._sse_frame({"jsonrpc": "2.0", "id": request_id, "ok": True, "result": None, "final": True})
+                async for frame in self._iter_sse_frames(
+                    ep=ep,
+                    handler_input=handler_input,
+                    payload=payload,
+                    request_id=request_id,
+                    transport=None,
+                ):
+                    yield frame
         except Exception as exc:
             yield self._sse_frame(
                 {
@@ -210,6 +202,49 @@ class StarletteBackend(BackendInterface):
                     "final": True,
                 }
             )
+
+    async def _iter_sse_frames(
+        self,
+        *,
+        ep: EndpointSpec,
+        handler_input: Any,
+        payload: Any,
+        request_id: str | None,
+        transport: "Transport | None",
+    ):
+        """Execute one SSE handler and yield successful protocol frames."""
+        if ep.request_source != "none" and payload is not None:
+            stream_obj = ep.handler(handler_input)
+        else:
+            stream_obj = ep.handler()
+
+        if inspect.isawaitable(stream_obj):
+            stream_obj = await stream_obj
+        if not hasattr(stream_obj, "__aiter__"):
+            raise TypeError("Streaming endpoint handler must return an async iterator")
+
+        sent_final = False
+        async for event in stream_obj:
+            event_payload = self._serialize_result(event)
+            if transport is not None:
+                transport.check_payload_limit(event_payload, kind="event")
+            event_final = bool(event_payload.get("final", False)) if isinstance(event_payload, dict) else False
+            stream_final = is_stream_terminal_event(event_payload, event_final=event_final)
+            yield self._sse_frame(
+                {
+                    "jsonrpc": "2.0",
+                    "id": request_id,
+                    "ok": True,
+                    "result": event_payload,
+                    "final": stream_final,
+                }
+            )
+            if stream_final:
+                sent_final = True
+                break
+
+        if not sent_final:
+            yield self._sse_frame({"jsonrpc": "2.0", "id": request_id, "ok": True, "result": None, "final": True})
 
     def _sse_frame(self, payload: dict[str, Any]) -> str:
         """Serialize a JSON payload as a single Server-Sent Event frame."""

--- a/protolink/transport/backends/starlette.py
+++ b/protolink/transport/backends/starlette.py
@@ -8,7 +8,7 @@ zero-overhead footprint and robust async routing capabilities.
 import asyncio
 import inspect
 import json
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from protolink.security.tls import TLSConfig
 from protolink.server.endpoint_handler import EndpointSpec
@@ -17,9 +17,19 @@ from protolink.transport._streaming import is_stream_terminal_event
 from protolink.transport.backends.base import BackendInterface
 from protolink.utils.inspect import is_async_callable
 
+if TYPE_CHECKING:
+    from protolink.transport.base import Transport
+
 
 class StarletteBackend(BackendInterface):
-    def __init__(self, *, log_level: str = "info", access_log: bool = True) -> None:
+    def __init__(
+        self,
+        *,
+        log_level: str = "info",
+        access_log: bool = True,
+        keepalive_timeout: float = 20.0,
+        limit_concurrency: int = 100,
+    ) -> None:
         Starlette, _, _, _, _ = _require_starlette()  # noqa: N806
 
         self.app = Starlette()
@@ -27,19 +37,26 @@ class StarletteBackend(BackendInterface):
         self._server_instance: Any = None
         self._log_level = log_level
         self._access_log = access_log
+        self._keepalive_timeout = keepalive_timeout
+        self._limit_concurrency = limit_concurrency
 
     # ----------------------------------------------------------------------
     # Setup Routes - Define Server URIs
     # ----------------------------------------------------------------------
 
-    def _register_endpoint(self, ep: EndpointSpec, authenticator: Any = None) -> None:
+    def _register_endpoint(
+        self,
+        ep: EndpointSpec,
+        authenticator: Any = None,
+        transport: "Transport | None" = None,
+    ) -> None:
         _, Request, JSONResponse, HTMLResponse, StreamingResponse = _require_starlette()  # noqa: N806
 
         async def route(request: Request):
             # -------------------------
             # Authenticate request
             # -------------------------
-            if authenticator:
+            if authenticator and ep.path not in {"/healthz", "/readyz"}:
                 from protolink.security.auth import extract_credentials
 
                 credentials = extract_credentials(request.headers, dict(request.query_params))
@@ -63,6 +80,9 @@ class StarletteBackend(BackendInterface):
             else:
                 payload = None
 
+            if transport is not None:
+                transport.check_payload_limit(payload, kind="request", url=str(request.url))
+
             # -------------------------
             # Parse payload
             # -------------------------
@@ -83,19 +103,36 @@ class StarletteBackend(BackendInterface):
                         handler_input=handler_input,
                         payload=payload,
                         request_id=request_id,
+                        transport=transport,
                     ),
                     media_type="text/event-stream",
+                    headers={"X-Protolink-Request-ID": request_id or ""},
                 )
+
+            raw_idempotency_key = request.headers.get("idempotency-key")
+            idempotency_key = f"{ep.method}:{ep.path}:{raw_idempotency_key}" if raw_idempotency_key else None
+            if transport is not None:
+                owns_operation, cached = await transport.acquire_idempotent_response(idempotency_key)
+                if not owns_operation:
+                    return JSONResponse(
+                        cached,
+                        headers={"X-Protolink-Request-ID": request.headers.get("x-protolink-request-id", "")},
+                    )
 
             # -------------------------
             # Call handler
             # -------------------------
             handler_is_async = is_async_callable(ep.handler)
 
-            if ep.request_source != "none" and payload is not None:
-                result = await ep.handler(handler_input) if handler_is_async else ep.handler(handler_input)
-            else:
-                result = await ep.handler() if handler_is_async else ep.handler()
+            try:
+                if ep.request_source != "none" and payload is not None:
+                    result = await ep.handler(handler_input) if handler_is_async else ep.handler(handler_input)
+                else:
+                    result = await ep.handler() if handler_is_async else ep.handler()
+            except BaseException as exc:
+                if transport is not None:
+                    transport.abort_idempotent_response(idempotency_key, exc)
+                raise
 
             # -------------------------
             # Response
@@ -104,11 +141,25 @@ class StarletteBackend(BackendInterface):
                 return HTMLResponse(result)
 
             serialized_result = self._serialize_result(result)
-            return JSONResponse(serialized_result)
+            if transport is not None:
+                transport.check_payload_limit(serialized_result, kind="response", url=str(request.url))
+                transport.complete_idempotent_response(idempotency_key, serialized_result)
+            return JSONResponse(
+                serialized_result,
+                headers={"X-Protolink-Request-ID": request.headers.get("x-protolink-request-id", "")},
+            )
 
         self.app.add_route(ep.path, route, methods=[ep.method])
 
-    async def _stream_sse(self, *, ep: EndpointSpec, handler_input: Any, payload: Any, request_id: str | None):
+    async def _stream_sse(
+        self,
+        *,
+        ep: EndpointSpec,
+        handler_input: Any,
+        payload: Any,
+        request_id: str | None,
+        transport: "Transport | None" = None,
+    ):
         """Yield JSON-RPC envelopes as Server-Sent Events.
 
         Streaming endpoint handlers return async iterators of Protolink events.
@@ -130,6 +181,8 @@ class StarletteBackend(BackendInterface):
             sent_final = False
             async for event in stream_obj:
                 event_payload = self._serialize_result(event)
+                if transport is not None:
+                    transport.check_payload_limit(event_payload, kind="event")
                 event_final = bool(event_payload.get("final", False)) if isinstance(event_payload, dict) else False
                 stream_final = is_stream_terminal_event(event_payload, event_final=event_final)
                 yield self._sse_frame(
@@ -162,7 +215,12 @@ class StarletteBackend(BackendInterface):
         """Serialize a JSON payload as a single Server-Sent Event frame."""
         return f"data: {json.dumps(payload)}\n\n"
 
-    def setup_routes(self, endpoints: list[EndpointSpec], authenticator: Any = None) -> None:
+    def setup_routes(
+        self,
+        endpoints: list[EndpointSpec],
+        authenticator: Any = None,
+        transport: "Transport | None" = None,
+    ) -> None:
         """Mount abstract Protolink endpoints as physical Starlette routes.
 
         This method serves as the architectural bridge between Protolink's `EndpointSpec` definitions
@@ -171,7 +229,7 @@ class StarletteBackend(BackendInterface):
         `JSONResponse` objects back over the wire.
         """
         for ep in endpoints:
-            self._register_endpoint(ep, authenticator=authenticator)
+            self._register_endpoint(ep, authenticator=authenticator, transport=transport)
 
     # ----------------------------------------------------------------------
     # ASGI Server Lifecycle
@@ -196,6 +254,8 @@ class StarletteBackend(BackendInterface):
             port=port,
             log_level=self._log_level,
             access_log=self._access_log,
+            limit_concurrency=self._limit_concurrency,
+            timeout_keep_alive=int(self._keepalive_timeout),
             **self._uvicorn_tls_kwargs(url, tls),
         )
         server = uvicorn.Server(config)

--- a/protolink/transport/base.py
+++ b/protolink/transport/base.py
@@ -7,16 +7,86 @@ Supports in-memory and JSON-RPC over HTTP/WebSocket.
 
 from __future__ import annotations
 
+import asyncio
+import concurrent.futures
+import json
+import random
+import threading
+import time
+import uuid
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any
+from collections import OrderedDict
+from collections.abc import AsyncIterator, Awaitable, Callable, Hashable
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, ClassVar, TypeVar
+
+from protolink.transport.config import TransportCapabilities, TransportConfig
+from protolink.transport.errors import TransportError, TransportLimitError
+from protolink.transport.metrics import TransportMetrics, TransportMetricsSnapshot
+from protolink.utils.serialization import Serializer
 
 if TYPE_CHECKING:
     from protolink.client.request_spec import ClientRequestSpec
     from protolink.server.endpoint_handler import EndpointSpec
 
 
+T = TypeVar("T")
+AsyncCloser = Callable[[], Awaitable[None]]
+
+
+@dataclass(frozen=True, slots=True)
+class TransportRequestContext:
+    """Correlation and idempotency metadata for one logical request.
+
+    Args:
+        request_id: Identifier retained across every attempt of the request.
+        idempotency_key: Optional operation key used for response deduplication.
+        attempt: One-based wire-attempt number.
+    """
+
+    request_id: str
+    idempotency_key: str | None = None
+    attempt: int = 1
+
+    def next_attempt(self) -> TransportRequestContext:
+        """Return context for the next retry attempt."""
+        return TransportRequestContext(
+            request_id=self.request_id,
+            idempotency_key=self.idempotency_key,
+            attempt=self.attempt + 1,
+        )
+
+
 class Transport(ABC):
-    """Abstract base class for transport implementations."""
+    """Abstract base class for transport implementations.
+
+    Concrete transports retain ownership of protocol I/O while this base class
+    provides one contract for capabilities, configuration, limits, retries,
+    metrics, correlation identifiers, and health reporting.
+    """
+
+    transport_type: ClassVar[str] = "custom"
+    supports_streaming: ClassVar[bool] = False
+    capabilities: ClassVar[TransportCapabilities] = TransportCapabilities()
+
+    def __init__(self, *, config: TransportConfig | None = None) -> None:
+        """Initialize shared production behavior for a concrete transport.
+
+        Args:
+            config: Limits, retries, keepalive, shutdown, idempotency, and
+                metrics settings. Defaults to a new ``TransportConfig``.
+        """
+        self.config = config or TransportConfig()
+        self._metrics = TransportMetrics(enabled=self.config.collect_metrics)
+        self._request_semaphores: dict[int, asyncio.Semaphore] = {}
+        self._stream_semaphores: dict[int, asyncio.Semaphore] = {}
+        self._resource_lock = threading.Lock()
+        self._loop_resources: dict[Hashable, tuple[asyncio.AbstractEventLoop, AsyncCloser]] = {}
+        self._idempotency_lock = threading.Lock()
+        self._idempotency_cache: OrderedDict[str, tuple[float, Any]] = OrderedDict()
+        self._idempotency_inflight: dict[str, concurrent.futures.Future[Any]] = {}
+        self._transport_running = False
 
     @abstractmethod
     async def send(
@@ -34,6 +104,12 @@ class Transport(ABC):
             The parsed response.
         """
         pass
+
+    async def subscribe(self, agent_url: str, task: Any) -> AsyncIterator[Any]:
+        """Stream events from a remote agent when supported."""
+        if False:  # pragma: no cover - preserves the async-iterator contract
+            yield None
+        raise NotImplementedError(f"{self.__class__.__name__} does not support streaming")
 
     @abstractmethod
     def setup_routes(self, endpoints: list[EndpointSpec]) -> None:
@@ -72,3 +148,293 @@ class Transport(ABC):
     def url(self) -> str:
         """Get the URL of the transport."""
         pass
+
+    @property
+    def metrics(self) -> TransportMetricsSnapshot:
+        """Return current dependency-free transport metrics."""
+        metrics = getattr(self, "_metrics", None)
+        return metrics.snapshot() if metrics is not None else TransportMetricsSnapshot()
+
+    @property
+    def is_running(self) -> bool:
+        """Whether the transport server is currently running."""
+        return bool(getattr(self, "_transport_running", False))
+
+    def health(self) -> dict[str, Any]:
+        """Return transport state, capabilities, and metrics as JSON-safe data."""
+        return {
+            "status": "ready" if self.is_running else "stopped",
+            "ready": self.is_running,
+            "transport": self.transport_type,
+            "url": self.url,
+            "capabilities": {
+                "networked": self.capabilities.networked,
+                "streaming": self.capabilities.streaming,
+                "tls": self.capabilities.tls,
+                "bidirectional": self.capabilities.bidirectional,
+                "persistent_connections": self.capabilities.persistent_connections,
+            },
+            "metrics": self.metrics.to_dict(),
+        }
+
+    def new_request_context(self, request_spec: ClientRequestSpec, data: Any = None) -> TransportRequestContext:
+        """Create correlation and idempotency metadata for a logical request.
+
+        Idempotent requests prefer a stable ``id``, ``task_id``, or
+        ``agent_url`` from the payload. Otherwise the generated request ID is
+        also used as the idempotency key.
+
+        Args:
+            request_spec: Operation contract controlling idempotency.
+            data: Optional domain model or mapping sent by the request.
+
+        Returns:
+            A first-attempt request context.
+        """
+        request_id = uuid.uuid4().hex
+        idempotency_key: str | None = None
+        if request_spec.idempotent:
+            candidate = getattr(data, "id", None) or getattr(data, "task_id", None)
+            if candidate is None and isinstance(data, dict):
+                candidate = data.get("id") or data.get("task_id") or data.get("agent_url")
+            idempotency_key = str(candidate) if candidate else request_id
+        return TransportRequestContext(request_id=request_id, idempotency_key=idempotency_key)
+
+    def register_loop_resource(self, key: Hashable, closer: AsyncCloser) -> None:
+        """Record an async resource and the event loop that owns it."""
+        loop = asyncio.get_running_loop()
+        with self._resource_lock:
+            self._loop_resources[key] = (loop, closer)
+
+    def discard_loop_resource(self, key: Hashable) -> None:
+        """Forget a closed or invalidated loop-owned resource."""
+        with self._resource_lock:
+            self._loop_resources.pop(key, None)
+
+    async def close_loop_resources(self) -> None:
+        """Close every pooled resource on its owning event loop.
+
+        Resources whose event loop has already stopped are forgotten because
+        asyncio cannot safely drive their asynchronous close operation.
+        """
+        with self._resource_lock:
+            resources = list(self._loop_resources.items())
+            self._loop_resources.clear()
+
+        current_loop = asyncio.get_running_loop()
+        for _key, (owner_loop, closer) in resources:
+            if owner_loop is current_loop:
+                await self._close_with_timeout(closer)
+                continue
+            if not owner_loop.is_running() or owner_loop.is_closed():
+                continue
+            future = asyncio.run_coroutine_threadsafe(self._run_closer(closer), owner_loop)
+            try:
+                await asyncio.wait_for(
+                    asyncio.wrap_future(future),
+                    timeout=self.config.shutdown_timeout,
+                )
+            except (TimeoutError, asyncio.CancelledError):
+                future.cancel()
+            except Exception:
+                continue
+
+    async def _close_with_timeout(self, closer: AsyncCloser) -> None:
+        """Run one asynchronous closer under the shutdown grace period."""
+        try:
+            await asyncio.wait_for(closer(), timeout=self.config.shutdown_timeout)
+        except asyncio.CancelledError:
+            return
+        except Exception:
+            return
+
+    @staticmethod
+    async def _run_closer(closer: AsyncCloser) -> None:
+        """Adapt a general awaitable closer to an asyncio coroutine."""
+        await closer()
+
+    async def acquire_idempotent_response(self, key: str | None) -> tuple[bool, Any | None]:
+        """Claim an idempotent operation or await its in-flight response.
+
+        Returns ``(True, None)`` to the request that should execute the
+        operation. Concurrent and later duplicates receive ``(False, result)``.
+        """
+        if key is None:
+            return True, None
+        now = time.monotonic()
+        with self._idempotency_lock:
+            cached = self._idempotency_cache.get(key)
+            if cached is not None:
+                created_at, response = cached
+                if now - created_at <= self.config.idempotency_ttl:
+                    self._idempotency_cache.move_to_end(key)
+                    return False, response
+                self._idempotency_cache.pop(key, None)
+
+            pending = self._idempotency_inflight.get(key)
+            if pending is None:
+                pending = concurrent.futures.Future()
+                pending.add_done_callback(self._consume_future_exception)
+                self._idempotency_inflight[key] = pending
+                return True, None
+
+        return False, await asyncio.wrap_future(pending)
+
+    def complete_idempotent_response(self, key: str | None, response: Any) -> None:
+        """Publish a completed response to concurrent and later duplicates."""
+        if key is None:
+            return
+        with self._idempotency_lock:
+            self._idempotency_cache[key] = (time.monotonic(), response)
+            self._idempotency_cache.move_to_end(key)
+            while len(self._idempotency_cache) > self.config.idempotency_cache_size:
+                self._idempotency_cache.popitem(last=False)
+            pending = self._idempotency_inflight.pop(key, None)
+        if pending is not None and not pending.done():
+            pending.set_result(response)
+
+    def abort_idempotent_response(self, key: str | None, error: BaseException) -> None:
+        """Release concurrent duplicates when the owning operation fails."""
+        if key is None:
+            return
+        with self._idempotency_lock:
+            pending = self._idempotency_inflight.pop(key, None)
+        if pending is not None and not pending.done():
+            pending.set_exception(error)
+
+    @staticmethod
+    def _consume_future_exception(future: concurrent.futures.Future[Any]) -> None:
+        """Mark shared-future exceptions as observed when no duplicate awaits them."""
+        if not future.cancelled():
+            future.exception()
+
+    def payload_size(self, payload: Any) -> int:
+        """Estimate serialized payload size using ProtoLink's normal serializer."""
+        if payload is None:
+            return 0
+        normalized = Serializer.serialize_to_dict(payload)
+        return len(json.dumps(normalized, separators=(",", ":"), default=str).encode("utf-8"))
+
+    def check_payload_limit(self, payload: Any, *, kind: str, url: str | None = None) -> int:
+        """Validate a serialized payload against configured byte limits."""
+        size = self.payload_size(payload)
+        limits = self.config.limits
+        maximum = {
+            "request": limits.max_request_bytes,
+            "response": limits.max_response_bytes,
+            "event": limits.max_event_bytes,
+        }[kind]
+        if size > maximum:
+            raise TransportLimitError(
+                f"Transport {kind} payload is {size} bytes; configured maximum is {maximum} bytes",
+                url=url,
+            )
+        return size
+
+    @asynccontextmanager
+    async def request_slot(self):
+        """Bound per-loop concurrent unary requests and update active metrics."""
+        loop_id = id(asyncio.get_running_loop())
+        semaphore = self._request_semaphores.setdefault(
+            loop_id,
+            asyncio.Semaphore(self.config.limits.max_concurrent_requests),
+        )
+        async with semaphore:
+            self._metrics.add(requests_started=1, active_requests=1)
+            try:
+                yield
+            finally:
+                self._metrics.add(active_requests=-1)
+
+    @asynccontextmanager
+    async def stream_slot(self):
+        """Bound per-loop concurrent streams and update active metrics."""
+        loop_id = id(asyncio.get_running_loop())
+        semaphore = self._stream_semaphores.setdefault(
+            loop_id,
+            asyncio.Semaphore(self.config.limits.max_concurrent_streams),
+        )
+        async with semaphore:
+            self._metrics.add(streams_started=1, active_streams=1)
+            try:
+                yield
+            except BaseException:
+                self._metrics.add(streams_failed=1)
+                raise
+            else:
+                self._metrics.add(streams_completed=1)
+            finally:
+                self._metrics.add(active_streams=-1)
+
+    @asynccontextmanager
+    async def inbound_request_slot(self):
+        """Bound inbound unary execution and record its complete outcome."""
+        loop_id = id(asyncio.get_running_loop())
+        semaphore = self._request_semaphores.setdefault(
+            loop_id,
+            asyncio.Semaphore(self.config.limits.max_concurrent_requests),
+        )
+        async with semaphore:
+            self._metrics.add(requests_started=1, active_requests=1)
+            started = time.perf_counter()
+            try:
+                yield
+            except BaseException:
+                self._metrics.add(
+                    requests_failed=1,
+                    total_latency_ms=(time.perf_counter() - started) * 1000,
+                )
+                raise
+            else:
+                self._metrics.add(
+                    requests_succeeded=1,
+                    total_latency_ms=(time.perf_counter() - started) * 1000,
+                )
+            finally:
+                self._metrics.add(active_requests=-1)
+
+    async def run_with_retries(
+        self,
+        request_spec: ClientRequestSpec,
+        context: TransportRequestContext,
+        operation: Callable[[TransportRequestContext], Awaitable[T]],
+    ) -> T:
+        """Run an operation under the configured idempotent retry policy."""
+        policy = self.config.retry
+        may_retry = request_spec.idempotent and request_spec.method.upper() in policy.retryable_methods
+        current = context
+        started = time.perf_counter()
+        last_error: TransportError | None = None
+
+        for attempt in range(1, policy.max_attempts + 1):
+            try:
+                result = await operation(current)
+                self._metrics.add(
+                    requests_succeeded=1,
+                    total_latency_ms=(time.perf_counter() - started) * 1000,
+                )
+                return result
+            except TransportError as exc:
+                last_error = exc
+                if not may_retry or not exc.retryable or attempt >= policy.max_attempts:
+                    self._metrics.add(
+                        requests_failed=1,
+                        total_latency_ms=(time.perf_counter() - started) * 1000,
+                    )
+                    raise
+                self._metrics.add(retries=1)
+                delay = min(policy.initial_backoff * (2 ** (attempt - 1)), policy.max_backoff)
+                if policy.jitter:
+                    delay += random.uniform(0, policy.jitter)
+                await asyncio.sleep(delay)
+                current = current.next_attempt()
+            except Exception:
+                self._metrics.add(
+                    requests_failed=1,
+                    total_latency_ms=(time.perf_counter() - started) * 1000,
+                )
+                raise
+
+        if last_error is not None:  # pragma: no cover - loop always returns or raises
+            raise last_error
+        raise RuntimeError("Retry loop exited without a result or transport error")

--- a/protolink/transport/config.py
+++ b/protolink/transport/config.py
@@ -1,0 +1,171 @@
+"""Shared configuration and capability declarations for ProtoLink transports."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class TransportCapabilities:
+    """Describe behavior guaranteed by a transport implementation.
+
+    Applications normally inspect this through ``transport.capabilities``
+    rather than constructing it directly.
+
+    Args:
+        networked: Whether the transport crosses a process/network boundary.
+        streaming: Whether ``subscribe()`` yields live task events.
+        tls: Whether the transport supports native TLS configuration.
+        bidirectional: Whether one connection can carry traffic both ways.
+        persistent_connections: Whether clients pool or retain connections.
+    """
+
+    networked: bool = True
+    streaming: bool = False
+    tls: bool = False
+    bidirectional: bool = False
+    persistent_connections: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class TransportLimits:
+    """Bound transport resource usage.
+
+    Args:
+        max_request_bytes: Maximum serialized outbound request size.
+        max_response_bytes: Maximum serialized unary response size.
+        max_event_bytes: Maximum serialized event size in a stream.
+        max_concurrent_requests: Per-event-loop unary request concurrency.
+        max_concurrent_streams: Per-event-loop active stream concurrency.
+    """
+
+    max_request_bytes: int = 16 * 1024 * 1024
+    max_response_bytes: int = 16 * 1024 * 1024
+    max_event_bytes: int = 4 * 1024 * 1024
+    max_concurrent_requests: int = 100
+    max_concurrent_streams: int = 100
+
+    def __post_init__(self) -> None:
+        """Reject limits that cannot safely bound resources."""
+        for name in (
+            "max_request_bytes",
+            "max_response_bytes",
+            "max_event_bytes",
+            "max_concurrent_requests",
+            "max_concurrent_streams",
+        ):
+            if getattr(self, name) <= 0:
+                raise ValueError(f"{name} must be greater than zero")
+
+    def to_dict(self) -> dict[str, int]:
+        """Return JSON-safe limit settings."""
+        return asdict(self)
+
+
+@dataclass(frozen=True, slots=True)
+class RetryPolicy:
+    """Configure bounded retries for explicitly idempotent requests.
+
+    ``max_attempts=1`` disables retries and is the default. ProtoLink never
+    retries a request unless its ``ClientRequestSpec`` declares it idempotent.
+
+    Args:
+        max_attempts: Total attempts including the initial call.
+        initial_backoff: Delay before the first retry in seconds.
+        max_backoff: Maximum delay between attempts in seconds.
+        jitter: Random delay added to each backoff in seconds.
+        retryable_methods: HTTP-style methods eligible for retry when the
+            request spec is also marked idempotent.
+    """
+
+    max_attempts: int = 1
+    initial_backoff: float = 0.1
+    max_backoff: float = 2.0
+    jitter: float = 0.1
+    retryable_methods: frozenset[str] = frozenset({"DELETE", "GET", "POST", "PUT"})
+
+    def __post_init__(self) -> None:
+        """Validate retry timing and attempt bounds."""
+        if self.max_attempts < 1:
+            raise ValueError("max_attempts must be at least one")
+        if self.initial_backoff < 0 or self.max_backoff < 0 or self.jitter < 0:
+            raise ValueError("retry backoff and jitter values must not be negative")
+        if self.max_backoff < self.initial_backoff:
+            raise ValueError("max_backoff must be greater than or equal to initial_backoff")
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return JSON-safe retry settings."""
+        return {
+            "max_attempts": self.max_attempts,
+            "initial_backoff": self.initial_backoff,
+            "max_backoff": self.max_backoff,
+            "jitter": self.jitter,
+            "retryable_methods": sorted(self.retryable_methods),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class TransportConfig:
+    """Configure production behavior shared by every transport.
+
+    The default configuration preserves existing behavior: requests are not
+    retried, metrics are collected locally, and conservative resource limits
+    protect network and in-process transports alike.
+
+    Args:
+        limits: Request, response, event, and concurrency limits.
+        retry: Retry policy for explicitly idempotent requests.
+        keepalive_interval: Optional connection keepalive interval in seconds.
+        keepalive_timeout: Seconds to wait for a keepalive response.
+        shutdown_timeout: Grace period for transport shutdown.
+        idempotency_ttl: Seconds to retain completed idempotent responses.
+        idempotency_cache_size: Maximum cached idempotent responses.
+        collect_metrics: Record in-process transport counters and latency.
+    """
+
+    limits: TransportLimits = field(default_factory=TransportLimits)
+    retry: RetryPolicy = field(default_factory=RetryPolicy)
+    keepalive_interval: float | None = 20.0
+    keepalive_timeout: float = 20.0
+    shutdown_timeout: float = 5.0
+    idempotency_ttl: float = 300.0
+    idempotency_cache_size: int = 1024
+    collect_metrics: bool = True
+
+    def __post_init__(self) -> None:
+        """Validate shared lifecycle and cache settings."""
+        if self.keepalive_interval is not None and self.keepalive_interval <= 0:
+            raise ValueError("keepalive_interval must be greater than zero or None")
+        if self.keepalive_timeout <= 0 or self.shutdown_timeout <= 0:
+            raise ValueError("keepalive_timeout and shutdown_timeout must be greater than zero")
+        if self.idempotency_ttl <= 0 or self.idempotency_cache_size <= 0:
+            raise ValueError("idempotency cache settings must be greater than zero")
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the complete transport configuration."""
+        return {
+            "limits": self.limits.to_dict(),
+            "retry": self.retry.to_dict(),
+            "keepalive_interval": self.keepalive_interval,
+            "keepalive_timeout": self.keepalive_timeout,
+            "shutdown_timeout": self.shutdown_timeout,
+            "idempotency_ttl": self.idempotency_ttl,
+            "idempotency_cache_size": self.idempotency_cache_size,
+            "collect_metrics": self.collect_metrics,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> TransportConfig:
+        """Restore a transport configuration from serialized data."""
+        values = dict(data)
+        limits_data = values.pop("limits", {})
+        retry_data = dict(values.pop("retry", {}))
+        methods = retry_data.get("retryable_methods")
+        if methods is not None:
+            retry_data["retryable_methods"] = frozenset(methods)
+        return cls(
+            limits=TransportLimits(**limits_data),
+            retry=RetryPolicy(**retry_data),
+            **values,
+        )

--- a/protolink/transport/errors.py
+++ b/protolink/transport/errors.py
@@ -1,0 +1,50 @@
+"""Typed exceptions raised consistently by ProtoLink transports."""
+
+from __future__ import annotations
+
+
+class TransportError(Exception):
+    """Base exception for transport-layer failures.
+
+    Args:
+        message: Human-readable failure description.
+        url: Remote or local endpoint associated with the failure.
+        request_id: Correlation identifier for the logical request.
+        retryable: Whether a retry policy may safely retry this failure.
+        status_code: Optional protocol-native status code.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        url: str | None = None,
+        request_id: str | None = None,
+        retryable: bool = False,
+        status_code: int | str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.url = url
+        self.request_id = request_id
+        self.retryable = retryable
+        self.status_code = status_code
+
+
+class TransportConnectionError(TransportError, ConnectionError):
+    """The transport could not establish or retain a connection."""
+
+
+class TransportTimeoutError(TransportError, TimeoutError):
+    """A transport operation exceeded its configured deadline."""
+
+
+class TransportProtocolError(TransportError, RuntimeError):
+    """A peer sent malformed or protocol-incompatible data."""
+
+
+class TransportRemoteError(TransportError, RuntimeError):
+    """A reachable peer rejected or failed the requested operation."""
+
+
+class TransportLimitError(TransportError, ValueError):
+    """A serialized request, response, or stream event exceeded its byte limit."""

--- a/protolink/transport/grpc_transport.py
+++ b/protolink/transport/grpc_transport.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 import asyncio
 import inspect
 import json
-import uuid
 from collections.abc import AsyncIterator
 from typing import Any, ClassVar, NoReturn
 from urllib.parse import urlparse
@@ -26,7 +25,14 @@ from protolink.security.tls import TLSConfig
 from protolink.server.endpoint_handler import EndpointSpec
 from protolink.transport._deps import _require_grpc
 from protolink.transport._streaming import is_stream_terminal_event
-from protolink.transport.base import Transport
+from protolink.transport.base import Transport, TransportRequestContext
+from protolink.transport.config import TransportCapabilities, TransportConfig
+from protolink.transport.errors import (
+    TransportConnectionError,
+    TransportProtocolError,
+    TransportRemoteError,
+    TransportTimeoutError,
+)
 from protolink.types import TransportType
 from protolink.utils.inspect import is_async_callable
 from protolink.utils.serialization import Serializer
@@ -69,10 +75,21 @@ class GRPCTransport(Transport):
     tls:
         Optional certificate and trust configuration used by ``grpcs://``
         servers and channels.
+    config:
+        Shared limits, retry, keepalive, shutdown, idempotency, and metrics settings.
+    enable_health:
+        Register the standard gRPC health service when its optional package is installed.
+    enable_reflection:
+        Register gRPC server reflection when its optional package is installed.
     """
 
     transport_type: ClassVar[TransportType] = "grpc"
     supports_streaming: ClassVar[bool] = True
+    capabilities: ClassVar[TransportCapabilities] = TransportCapabilities(
+        streaming=True,
+        tls=True,
+        persistent_connections=True,
+    )
 
     _SERVICE_NAME: ClassVar[str] = "protolink.transport.v1.ProtolinkTransport"
     _INVOKE_METHOD: ClassVar[str] = f"/{_SERVICE_NAME}/Invoke"
@@ -91,7 +108,12 @@ class GRPCTransport(Transport):
         maximum_concurrent_rpcs: int | None = None,
         graceful_shutdown_timeout: float = 3.0,
         tls: TLSConfig | None = None,
+        config: TransportConfig | None = None,
+        enable_health: bool = True,
+        enable_reflection: bool = True,
     ) -> None:
+        """Initialize a loop-safe generic gRPC client/server transport."""
+        super().__init__(config=config)
         self._grpc = _require_grpc()
         self._url = url
         self._timeout = timeout
@@ -104,11 +126,31 @@ class GRPCTransport(Transport):
         self._server: Any | None = None
         self._is_running = False
         self._channels: dict[tuple[str, bool, int], Any] = {}
-        self._channel_options = tuple(channel_options or ())
-        self._server_options = tuple(server_options or ())
+        self._channel_options = self._merge_options(
+            (
+                ("grpc.keepalive_time_ms", int((self.config.keepalive_interval or 0) * 1000)),
+                ("grpc.keepalive_timeout_ms", int(self.config.keepalive_timeout * 1000)),
+                ("grpc.max_send_message_length", self.config.limits.max_request_bytes),
+                ("grpc.max_receive_message_length", self.config.limits.max_response_bytes),
+            ),
+            channel_options,
+        )
+        self._server_options = self._merge_options(
+            (
+                ("grpc.max_receive_message_length", self.config.limits.max_request_bytes),
+                (
+                    "grpc.max_send_message_length",
+                    max(self.config.limits.max_response_bytes, self.config.limits.max_event_bytes),
+                ),
+            ),
+            server_options,
+        )
         self._compression = compression
-        self._maximum_concurrent_rpcs = maximum_concurrent_rpcs
+        self._maximum_concurrent_rpcs = maximum_concurrent_rpcs or self.config.limits.max_concurrent_requests
         self._graceful_shutdown_timeout = graceful_shutdown_timeout
+        self._enable_health = enable_health
+        self._enable_reflection = enable_reflection
+        self._health_servicer: Any | None = None
 
     # ------------------------------------------------------------------
     # Server routing and lifecycle
@@ -126,6 +168,8 @@ class GRPCTransport(Transport):
 
     async def start(self) -> None:
         """Start the ``grpc.aio`` server and register generic RPC handlers."""
+        if self._is_running:
+            return
         host, port = self._get_host_port(self._url)
         if not host or port is None:
             raise ValueError(f"Invalid URL: {self._url}. Expected grpc://host:port or grpcs://host:port.")
@@ -151,6 +195,7 @@ class GRPCTransport(Transport):
             },
         )
         self._server.add_generic_rpc_handlers((generic_handler,))
+        await self._setup_operational_services()
 
         if self._is_secure_url(self._url):
             if self.tls is None:
@@ -171,19 +216,23 @@ class GRPCTransport(Transport):
 
         await self._server.start()
         self._is_running = True
+        self._transport_running = True
 
     async def stop(self) -> None:
         """Stop the gRPC server and close caller-loop client channels."""
+        await self._set_health_status(serving=False)
         if self._server is not None:
             await self._server.stop(self._graceful_shutdown_timeout)
             self._server = None
             self._is_running = False
 
+        await self.close_loop_resources()
         loop_id = id(asyncio.get_running_loop())
-        channels = [(key, channel) for key, channel in self._channels.items() if key[2] == loop_id]
-        for key, channel in channels:
-            await channel.close(grace=1.0)
-            self._channels.pop(key, None)
+        for key, channel in list(self._channels.items()):
+            if key[2] == loop_id:
+                await channel.close(grace=1.0)
+                self._channels.pop(key, None)
+        self._transport_running = False
 
     # ------------------------------------------------------------------
     # Client
@@ -206,31 +255,46 @@ class GRPCTransport(Transport):
         if self.authenticator and self.credentials and not self.security_context:
             await self.authenticate(self.credentials)
 
-        request_id = uuid.uuid4().hex
-        payload = self._build_request_payload(
-            request_id=request_id,
-            method=request_spec.method,
-            path=request_spec.path,
-            request_source=request_spec.request_source,
-            data=data,
-            params=params,
-        )
+        context = self.new_request_context(request_spec, data)
 
-        channel = await self._ensure_channel(base_url)
-        invoke = channel.unary_unary(
-            self._INVOKE_METHOD,
-            request_serializer=self._encode_message,
-            response_deserializer=self._decode_message,
-        )
-        try:
-            response = await invoke(payload, timeout=self._timeout, metadata=self._build_metadata())
-        except self._grpc.aio.AioRpcError as exc:
-            self._raise_rpc_error(exc, base_url, operation="request")
+        async def operation(attempt: TransportRequestContext) -> Any:
+            payload = self._build_request_payload(
+                request_id=attempt.request_id,
+                idempotency_key=attempt.idempotency_key,
+                method=request_spec.method,
+                path=request_spec.path,
+                request_source=request_spec.request_source,
+                data=data,
+                params=params,
+            )
+            request_size = self.check_payload_limit(payload, kind="request", url=base_url)
+            channel = await self._ensure_channel(base_url)
+            invoke = channel.unary_unary(
+                self._INVOKE_METHOD,
+                request_serializer=self._encode_message,
+                response_deserializer=self._decode_message,
+            )
+            try:
+                self._metrics.add(bytes_sent=request_size)
+                response = await invoke(
+                    payload,
+                    timeout=self._timeout,
+                    metadata=self._build_metadata(attempt),
+                )
+            except self._grpc.aio.AioRpcError as exc:
+                self._raise_rpc_error(exc, base_url, operation="request", request_id=attempt.request_id)
+            result = self._unwrap_response(
+                response,
+                request_id=attempt.request_id,
+                base_url=base_url,
+                operation="request",
+            )
+            response_size = self.check_payload_limit(result, kind="response", url=base_url)
+            self._metrics.add(bytes_received=response_size)
+            return request_spec.response_parser(result) if request_spec.response_parser else result
 
-        result = self._unwrap_response(response, request_id=request_id, base_url=base_url, operation="request")
-        if request_spec.response_parser:
-            return request_spec.response_parser(result)
-        return result
+        async with self.request_slot():
+            return await self.run_with_retries(request_spec, context, operation)
 
     async def subscribe(self, agent_url: str, task: Any) -> AsyncIterator[Any]:
         """Stream task events from a remote agent over gRPC unary-stream RPCs.
@@ -243,9 +307,17 @@ class GRPCTransport(Transport):
         if self.authenticator and self.credentials and not self.security_context:
             await self.authenticate(self.credentials)
 
-        request_id = uuid.uuid4().hex
+        request_spec = ClientRequestSpec(
+            name="task_stream",
+            path="/tasks/stream",
+            method="POST",
+            request_source="body",
+        )
+        request_context = self.new_request_context(request_spec, task)
+        request_id = request_context.request_id
         payload = self._build_request_payload(
             request_id=request_id,
+            idempotency_key=None,
             method="POST",
             path="/tasks/stream",
             request_source="body",
@@ -253,27 +325,32 @@ class GRPCTransport(Transport):
             params=None,
         )
 
-        channel = await self._ensure_channel(agent_url)
-        stream = channel.unary_stream(
-            self._STREAM_METHOD,
-            request_serializer=self._encode_message,
-            response_deserializer=self._decode_message,
-        )
-        try:
-            call = stream(payload, timeout=self._timeout, metadata=self._build_metadata())
-            async for response in call:
-                result = self._unwrap_response(
-                    response,
-                    request_id=request_id,
-                    base_url=agent_url,
-                    operation="stream",
-                )
-                if result is not None:
-                    yield result
-                if response.get("final", False):
-                    break
-        except self._grpc.aio.AioRpcError as exc:
-            self._raise_rpc_error(exc, agent_url, operation="stream")
+        request_size = self.check_payload_limit(payload, kind="request", url=agent_url)
+        async with self.stream_slot():
+            channel = await self._ensure_channel(agent_url)
+            stream = channel.unary_stream(
+                self._STREAM_METHOD,
+                request_serializer=self._encode_message,
+                response_deserializer=self._decode_message,
+            )
+            try:
+                self._metrics.add(bytes_sent=request_size)
+                call = stream(payload, timeout=self._timeout, metadata=self._build_metadata(request_context))
+                async for response in call:
+                    result = self._unwrap_response(
+                        response,
+                        request_id=request_id,
+                        base_url=agent_url,
+                        operation="stream",
+                    )
+                    if result is not None:
+                        event_size = self.check_payload_limit(result, kind="event", url=agent_url)
+                        self._metrics.add(bytes_received=event_size)
+                        yield result
+                    if response.get("final", False):
+                        break
+            except self._grpc.aio.AioRpcError as exc:
+                self._raise_rpc_error(exc, agent_url, operation="stream", request_id=request_id)
 
     async def authenticate(self, credentials: str) -> None:
         """Authenticate outbound credentials and store the resulting context."""
@@ -289,20 +366,38 @@ class GRPCTransport(Transport):
         """Handle one ``Invoke`` RPC by routing the request envelope."""
         await self._authenticate_context(context)
         request_id = request.get("id") if isinstance(request, dict) else None
+        idempotency_key: str | None = None
 
         try:
             endpoint, payload = await self._prepare_endpoint_request(request)
             if endpoint.mode == "stream" or endpoint.streaming:
                 raise ValueError(f"Endpoint {endpoint.method} {endpoint.path} requires the gRPC Stream method")
 
-            result = await self._call_endpoint(endpoint, payload)
-            return {
+            raw_idempotency_key = request.get("idempotency_key")
+            idempotency_key = (
+                f"{endpoint.method}:{endpoint.path}:{raw_idempotency_key}" if raw_idempotency_key else None
+            )
+            owns_operation, cached = await self.acquire_idempotent_response(idempotency_key)
+            if not owns_operation:
+                if not isinstance(cached, dict):
+                    raise TypeError("Cached gRPC response must be a mapping")
+                cached_response = cached.copy()
+                cached_response["id"] = request_id
+                return cached_response
+            async with self.inbound_request_slot():
+                result = await self._call_endpoint(endpoint, payload)
+            response = {
                 "id": request_id,
                 "ok": True,
                 "result": self._serialize_result(result),
             }
+            self.check_payload_limit(response, kind="response", url=self._url)
+            self.complete_idempotent_response(idempotency_key, response)
+            return response
         except Exception as exc:
-            return self._error_response(request_id, exc)
+            response = self._error_response(request_id, exc)
+            self.complete_idempotent_response(idempotency_key, response)
+            return response
 
     async def _handle_stream(self, request: dict[str, Any], context: Any) -> AsyncIterator[dict[str, Any]]:
         """Handle one ``Stream`` RPC by yielding response envelopes."""
@@ -314,36 +409,24 @@ class GRPCTransport(Transport):
             if endpoint.mode != "stream" and not endpoint.streaming:
                 raise ValueError(f"Endpoint {endpoint.method} {endpoint.path} is not a streaming endpoint")
 
-            handler_input = await self._parse_payload(endpoint, payload)
-            if endpoint.request_source != "none" and payload is not None:
-                stream_obj = endpoint.handler(handler_input)
-            else:
-                stream_obj = endpoint.handler()
+            async with self.stream_slot():
+                sent_final = False
+                async for event_payload in self._iterate_endpoint_stream(endpoint, payload):
+                    event_final = bool(event_payload.get("final", False)) if isinstance(event_payload, dict) else False
+                    stream_final = is_stream_terminal_event(event_payload, event_final=event_final)
+                    yield {
+                        "id": request_id,
+                        "ok": True,
+                        "result": event_payload,
+                        "final": stream_final,
+                        "stream": True,
+                    }
+                    if stream_final:
+                        sent_final = True
+                        break
 
-            if inspect.isawaitable(stream_obj):
-                stream_obj = await stream_obj
-
-            if not hasattr(stream_obj, "__aiter__"):
-                raise TypeError("Streaming endpoint handler must return an async iterator")
-
-            sent_final = False
-            async for event in stream_obj:
-                event_payload = self._serialize_result(event)
-                event_final = bool(event_payload.get("final", False)) if isinstance(event_payload, dict) else False
-                stream_final = is_stream_terminal_event(event_payload, event_final=event_final)
-                yield {
-                    "id": request_id,
-                    "ok": True,
-                    "result": event_payload,
-                    "final": stream_final,
-                    "stream": True,
-                }
-                if stream_final:
-                    sent_final = True
-                    break
-
-            if not sent_final:
-                yield {"id": request_id, "ok": True, "result": None, "final": True, "stream": True}
+                if not sent_final:
+                    yield {"id": request_id, "ok": True, "result": None, "final": True, "stream": True}
         except Exception as exc:
             yield self._error_response(request_id, exc, final=True, stream=True)
 
@@ -402,6 +485,22 @@ class GRPCTransport(Transport):
             return await endpoint.handler(handler_input) if handler_is_async else endpoint.handler(handler_input)
         return await endpoint.handler() if handler_is_async else endpoint.handler()
 
+    async def _iterate_endpoint_stream(self, endpoint: EndpointSpec, payload: Any) -> AsyncIterator[Any]:
+        """Parse and iterate one bounded server-side streaming handler."""
+        handler_input = await self._parse_payload(endpoint, payload)
+        if endpoint.request_source != "none" and payload is not None:
+            stream_obj = endpoint.handler(handler_input)
+        else:
+            stream_obj = endpoint.handler()
+        if inspect.isawaitable(stream_obj):
+            stream_obj = await stream_obj
+        if not hasattr(stream_obj, "__aiter__"):
+            raise TypeError("Streaming endpoint handler must return an async iterator")
+        async for event in stream_obj:
+            event_payload = self._serialize_result(event)
+            self.check_payload_limit(event_payload, kind="event", url=self._url)
+            yield event_payload
+
     # ------------------------------------------------------------------
     # Serialization and envelope helpers
     # ------------------------------------------------------------------
@@ -410,6 +509,7 @@ class GRPCTransport(Transport):
         self,
         *,
         request_id: str,
+        idempotency_key: str | None,
         method: str,
         path: str,
         request_source: str,
@@ -422,6 +522,8 @@ class GRPCTransport(Transport):
             "method": method,
             "path": path,
         }
+        if idempotency_key:
+            payload["idempotency_key"] = idempotency_key
 
         if request_source == "body" and data is not None:
             payload["data"] = self._serialize_result(data)
@@ -463,11 +565,19 @@ class GRPCTransport(Transport):
         """Validate and unwrap a response envelope from a remote peer."""
         message_id = response.get("id")
         if message_id not in {None, request_id}:
-            raise RuntimeError(f"Mismatched gRPC {operation} id from {base_url}: {message_id}")
+            raise TransportProtocolError(
+                f"Mismatched gRPC {operation} id from {base_url}: {message_id}",
+                url=base_url,
+                request_id=request_id,
+            )
 
         if not response.get("ok", False):
             error = response.get("error") or {}
-            raise RuntimeError(f"gRPC {operation} failed at {base_url}: {error}")
+            raise TransportRemoteError(
+                f"gRPC {operation} failed at {base_url}: {error}",
+                url=base_url,
+                request_id=request_id,
+            )
 
         return response.get("result")
 
@@ -491,6 +601,51 @@ class GRPCTransport(Transport):
             response["stream"] = True
         return response
 
+    async def _setup_operational_services(self) -> None:
+        """Register standard gRPC health and reflection services when installed."""
+        if self._server is None or (not self._enable_health and not self._enable_reflection):
+            return
+        try:
+            from grpc_health.v1 import health, health_pb2_grpc
+            from grpc_reflection.v1alpha import reflection
+        except ImportError:
+            return
+
+        service_names = [self._SERVICE_NAME]
+        if self._enable_health:
+            health_api = getattr(health, "aio", health)
+            self._health_servicer = health_api.HealthServicer()
+            health_pb2_grpc.add_HealthServicer_to_server(self._health_servicer, self._server)
+            service_names.append("grpc.health.v1.Health")
+            await self._set_health_status(serving=True)
+        if self._enable_reflection:
+            service_names.append(reflection.SERVICE_NAME)
+            reflection.enable_server_reflection(tuple(service_names), self._server)
+
+    async def _set_health_status(self, *, serving: bool) -> None:
+        """Update standard gRPC health status for all exposed service names."""
+        if self._health_servicer is None:
+            return
+        try:
+            from grpc_health.v1 import health_pb2
+        except ImportError:
+            return
+        status = health_pb2.HealthCheckResponse.SERVING if serving else health_pb2.HealthCheckResponse.NOT_SERVING
+        for service_name in ("", self._SERVICE_NAME):
+            result = self._health_servicer.set(service_name, status)
+            if inspect.isawaitable(result):
+                await result
+
+    @staticmethod
+    def _merge_options(
+        defaults: tuple[tuple[str, Any], ...],
+        overrides: list[tuple[str, Any]] | tuple[tuple[str, Any], ...] | None,
+    ) -> tuple[tuple[str, Any], ...]:
+        """Merge gRPC options while giving explicit caller values precedence."""
+        merged = dict(defaults)
+        merged.update(dict(overrides or ()))
+        return tuple(merged.items())
+
     # ------------------------------------------------------------------
     # Authentication and channels
     # ------------------------------------------------------------------
@@ -511,9 +666,13 @@ class GRPCTransport(Transport):
         except Exception as exc:
             await context.abort(self._grpc.StatusCode.UNAUTHENTICATED, f"Authentication failed: {exc}")
 
-    def _build_metadata(self) -> tuple[tuple[str, str], ...]:
+    def _build_metadata(self, context: TransportRequestContext) -> tuple[tuple[str, str], ...]:
         """Build lowercase gRPC metadata from the active security context."""
-        return tuple((key.lower(), value) for key, value in self._build_headers().items())
+        metadata = [(key.lower(), value) for key, value in self._build_headers().items()]
+        metadata.append(("x-protolink-request-id", context.request_id))
+        if context.idempotency_key:
+            metadata.append(("idempotency-key", context.idempotency_key))
+        return tuple(metadata)
 
     def _build_headers(self) -> dict[str, str]:
         """Construct authentication headers shared with other network transports."""
@@ -568,6 +727,12 @@ class GRPCTransport(Transport):
                     compression=self._compression,
                 )
             self._channels[key] = channel
+
+            async def close_channel() -> None:
+                await channel.close(grace=1.0)
+                self._channels.pop(key, None)
+
+            self.register_loop_resource(("grpc", key), close_channel)
         return channel
 
     @staticmethod
@@ -587,17 +752,31 @@ class GRPCTransport(Transport):
             pairs.append((str(key), str(value)))
         return pairs
 
-    def _raise_rpc_error(self, exc: Any, base_url: str, *, operation: str) -> NoReturn:
+    def _raise_rpc_error(self, exc: Any, base_url: str, *, operation: str, request_id: str) -> NoReturn:
         """Translate grpcio exceptions into Protolink-style client errors."""
         code = exc.code()
         details = exc.details()
         if code == self._grpc.StatusCode.UNAVAILABLE:
-            raise ConnectionError(
-                f"Failed to connect to agent at {base_url}. Make sure the gRPC agent is running and accessible."
+            raise TransportConnectionError(
+                f"Failed to connect to agent at {base_url}. Make sure the gRPC agent is running and accessible.",
+                url=base_url,
+                request_id=request_id,
+                retryable=True,
             ) from exc
         if code == self._grpc.StatusCode.DEADLINE_EXCEEDED:
-            raise TimeoutError(f"gRPC {operation} to {base_url} exceeded {self._timeout} seconds") from exc
-        raise RuntimeError(f"gRPC {operation} failed at {base_url}: {code.name}: {details}") from exc
+            raise TransportTimeoutError(
+                f"gRPC {operation} to {base_url} exceeded {self._timeout} seconds",
+                url=base_url,
+                request_id=request_id,
+                retryable=True,
+            ) from exc
+        raise TransportRemoteError(
+            f"gRPC {operation} failed at {base_url}: {code.name}: {details}",
+            url=base_url,
+            request_id=request_id,
+            retryable=code in {self._grpc.StatusCode.RESOURCE_EXHAUSTED, self._grpc.StatusCode.INTERNAL},
+            status_code=code.name,
+        ) from exc
 
     # ------------------------------------------------------------------
     # Utilities

--- a/protolink/transport/grpc_transport.py
+++ b/protolink/transport/grpc_transport.py
@@ -394,9 +394,12 @@ class GRPCTransport(Transport):
             self.check_payload_limit(response, kind="response", url=self._url)
             self.complete_idempotent_response(idempotency_key, response)
             return response
+        except asyncio.CancelledError as exc:
+            self.abort_idempotent_response(idempotency_key, exc)
+            raise
         except Exception as exc:
             response = self._error_response(request_id, exc)
-            self.complete_idempotent_response(idempotency_key, response)
+            self.abort_idempotent_response(idempotency_key, exc)
             return response
 
     async def _handle_stream(self, request: dict[str, Any], context: Any) -> AsyncIterator[dict[str, Any]]:

--- a/protolink/transport/http_transport.py
+++ b/protolink/transport/http_transport.py
@@ -14,6 +14,8 @@ network boundary for Protolink agents. It facilitates the bidirectional transmis
   as an outbound client on the main thread without triggering `asyncio` loop contamination.
 """
 
+import asyncio
+import json
 from typing import Any, ClassVar
 
 import httpx
@@ -24,7 +26,14 @@ from protolink.security.auth import Authenticator
 from protolink.security.tls import TLSConfig
 from protolink.server.endpoint_handler import EndpointSpec
 from protolink.transport.backends import BackendInterface, FastAPIBackend, StarletteBackend
-from protolink.transport.base import Transport
+from protolink.transport.base import Transport, TransportRequestContext
+from protolink.transport.config import TransportCapabilities, TransportConfig
+from protolink.transport.errors import (
+    TransportConnectionError,
+    TransportProtocolError,
+    TransportRemoteError,
+    TransportTimeoutError,
+)
 from protolink.types import BackendType, TransportType
 
 
@@ -56,10 +65,16 @@ class HTTPTransport(Transport):
     tls:
         Optional TLS certificate and trust configuration. Use an ``https://``
         server URL to enable TLS.
+    config:
+        Shared limits, retry, keepalive, shutdown, idempotency, and metrics settings.
     """
 
     transport_type: ClassVar[TransportType] = "http"
     supports_streaming: ClassVar[bool] = False
+    capabilities: ClassVar[TransportCapabilities] = TransportCapabilities(
+        tls=True,
+        persistent_connections=True,
+    )
 
     def __init__(
         self,
@@ -71,10 +86,11 @@ class HTTPTransport(Transport):
         validate_schema: bool = False,
         credentials: str | None = None,
         tls: TLSConfig | None = None,
+        config: TransportConfig | None = None,
         log_level: str = "info",
         access_log: bool = True,
     ) -> None:
-        """Initialize HTTP transport. and underlying ASGI server framework.
+        """Initialize the HTTP client/server transport and ASGI backend.
 
         Args:
             url: The absolute URL (e.g., ``"http://localhost:8000"``) dictating both the
@@ -88,7 +104,11 @@ class HTTPTransport(Transport):
             validate_schema: If true, instructs the selected backend (such as FastAPI)
                              to enforce strict Pydantic model validation on inbound payloads.
             tls: Optional transport-security configuration for HTTPS and mutual TLS.
+            config: Shared production transport behavior.
+            log_level: Uvicorn log level.
+            access_log: Whether Uvicorn emits request access logs.
         """
+        super().__init__(config=config)
         self._url: str = url
         self._timeout: float = timeout
         self.authenticator: Authenticator | None = authenticator
@@ -108,9 +128,16 @@ class HTTPTransport(Transport):
                 validate_schema=validate_schema,
                 log_level=log_level,
                 access_log=access_log,
+                keepalive_timeout=self.config.keepalive_timeout,
+                limit_concurrency=self.config.limits.max_concurrent_requests,
             )
         else:
-            self.backend = StarletteBackend(log_level=log_level, access_log=access_log)
+            self.backend = StarletteBackend(
+                log_level=log_level,
+                access_log=access_log,
+                keepalive_timeout=self.config.keepalive_timeout,
+                limit_concurrency=self.config.limits.max_concurrent_requests,
+            )
 
     # ------------------------------------------------------------------
     # Client
@@ -137,61 +164,81 @@ class HTTPTransport(Transport):
         RuntimeError
             If the remote endpoint returns a non-200 HTTP status code.
         """
-        if self.authenticator and self.credentials and not self.security_context:
-            await self.authenticate(self.credentials)
-
-        client = await self._ensure_client()
-        headers = self._build_headers()
-
-        # Build URL
         url = f"{base_url.rstrip('/')}{request_spec.path}"
+        request_size = self.check_payload_limit({"data": data, "params": params}, kind="request", url=url)
+        context = self.new_request_context(request_spec, data)
 
-        # Prepare request arguments
-        kwargs: dict[str, Any] = {"headers": headers}
-        if params:
-            kwargs["params"] = params
+        async def operation(attempt: TransportRequestContext) -> Any:
+            if self.authenticator and self.credentials and not self.security_context:
+                await self.authenticate(self.credentials)
 
-        if request_spec.request_source == "body" and data is not None:
-            # Handle Pydantic models automatically
-            if hasattr(data, "to_json"):
-                kwargs["json"] = data.to_json()
-            elif hasattr(data, "to_dict"):
-                kwargs["json"] = data.to_dict()
-            elif isinstance(data, BaseModel):
-                kwargs["json"] = data.model_dump()
-            elif isinstance(data, dict):
-                kwargs["json"] = data
-            else:
-                # TODO: Fallback/Error? Assuming dict or compatible
-                kwargs["json"] = data
-        elif request_spec.request_source == "query_params" and data is not None:
-            # Send data as query parameters
-            if isinstance(data, dict):
-                kwargs["params"] = data
-            else:
-                # For single values, wrap in dict
-                kwargs["params"] = {"data": str(data)}
+            client = await self._ensure_client()
+            headers = {
+                **self._build_headers(),
+                "X-Protolink-Request-ID": attempt.request_id,
+            }
+            if attempt.idempotency_key:
+                headers["Idempotency-Key"] = attempt.idempotency_key
 
-        try:
-            response = await client.request(request_spec.method, url, timeout=self._timeout, **kwargs)
-            response.raise_for_status()
+            kwargs: dict[str, Any] = {"headers": headers}
+            if params:
+                kwargs["params"] = params
+            if request_spec.request_source == "body" and data is not None:
+                kwargs["json"] = self._serialize_payload(data)
+            elif request_spec.request_source == "query_params" and data is not None:
+                kwargs["params"] = data if isinstance(data, dict) else {"data": str(data)}
 
-            # Parse response
-            if request_spec.response_parser:
-                return request_spec.response_parser(response.json())
-            return response.json()
+            try:
+                self._metrics.add(bytes_sent=request_size)
+                response = await client.request(request_spec.method, url, timeout=self._timeout, **kwargs)
+                response.raise_for_status()
+            except httpx.TimeoutException as exc:
+                raise TransportTimeoutError(
+                    f"HTTP request to {base_url} timed out",
+                    url=url,
+                    request_id=attempt.request_id,
+                    retryable=True,
+                ) from exc
+            except httpx.ConnectError as exc:
+                raise TransportConnectionError(
+                    f"Failed to connect to agent at {base_url}. Make sure the agent is running and accessible.",
+                    url=url,
+                    request_id=attempt.request_id,
+                    retryable=True,
+                ) from exc
+            except httpx.RemoteProtocolError as exc:
+                raise TransportProtocolError(
+                    f"Protocol error when communicating with agent at {base_url}",
+                    url=url,
+                    request_id=attempt.request_id,
+                    retryable=True,
+                ) from exc
+            except httpx.HTTPStatusError as exc:
+                status = exc.response.status_code
+                raise TransportRemoteError(
+                    f"Agent at {base_url} returned HTTP {status}: {exc.response.text}",
+                    url=url,
+                    request_id=attempt.request_id,
+                    retryable=status == 429 or status >= 500,
+                    status_code=status,
+                ) from exc
 
-        except httpx.ConnectError as e:
-            raise ConnectionError(
-                f"Failed to connect to agent at {base_url}. Make sure the agent is running and accessible."
-            ) from e
-        except httpx.RemoteProtocolError as e:
-            raise ConnectionError(
-                f"Protocol error when communicating with agent at {base_url}. "
-                f"The target may not be a proper HTTP server or may be misconfigured."
-            ) from e
-        except httpx.HTTPStatusError as e:
-            raise RuntimeError(f"Agent at {base_url} returned HTTP {e.response.status_code}: {e.response.text}") from e
+            response_size = len(response.content)
+            if response_size > self.config.limits.max_response_bytes:
+                self.check_payload_limit(response.text, kind="response", url=url)
+            self._metrics.add(bytes_received=response_size)
+            try:
+                payload = response.json()
+            except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+                raise TransportProtocolError(
+                    f"Agent at {base_url} returned invalid JSON",
+                    url=url,
+                    request_id=attempt.request_id,
+                ) from exc
+            return request_spec.response_parser(payload) if request_spec.response_parser else payload
+
+        async with self.request_slot():
+            return await self.run_with_retries(request_spec, context, operation)
 
     async def _ensure_client(self) -> httpx.AsyncClient:
         """Return an initialized :class:`httpx.AsyncClient` instance for the current loop.
@@ -202,20 +249,27 @@ class HTTPTransport(Transport):
         the same underlying sockets or locks, avoiding `Future attached to a different loop`
         exceptions.
         """
-        import asyncio
-
         loop_id = id(asyncio.get_running_loop())
         client = self._clients.get(loop_id)
         if not client or client.is_closed:
             client = self._create_client()
             self._clients[loop_id] = client
+            self.register_loop_resource(
+                ("http", loop_id),
+                client.aclose,
+            )
         return client
 
     def _create_client(self) -> httpx.AsyncClient:
         """Create an HTTP client using configured TLS trust and identity."""
+        limits = httpx.Limits(
+            max_connections=self.config.limits.max_concurrent_requests,
+            max_keepalive_connections=self.config.limits.max_concurrent_requests,
+            keepalive_expiry=self.config.keepalive_interval,
+        )
         if self.tls is None:
-            return httpx.AsyncClient(timeout=self._timeout)
-        return httpx.AsyncClient(timeout=self._timeout, verify=self.tls.create_client_context())
+            return httpx.AsyncClient(timeout=self._timeout, limits=limits)
+        return httpx.AsyncClient(timeout=self._timeout, limits=limits, verify=self.tls.create_client_context())
 
     # ------------------------------------------------------------------
     # Server Routing
@@ -228,7 +282,7 @@ class HTTPTransport(Transport):
         or ``FastAPIBackend``) which binds the abstract ``EndpointSpec`` models into tangible
         RESTful routes on the underlying server application.
         """
-        self.backend.setup_routes(endpoints, authenticator=self.authenticator)
+        self.backend.setup_routes(endpoints, authenticator=self.authenticator, transport=self)
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -251,12 +305,12 @@ class HTTPTransport(Transport):
         the current thread's loop selector, preventing cross-loop boundary violations.
         """
 
+        if self._transport_running:
+            return
         await self.backend.start(self._url, tls=self.tls)
+        self._transport_running = True
 
-        import asyncio
-
-        loop_id = id(asyncio.get_running_loop())
-        self._clients[loop_id] = self._create_client()
+        await self._ensure_client()
 
     async def stop(self) -> None:
         """Stop the HTTP server and gracefully close the loop-isolated HTTP client pool.
@@ -276,15 +330,11 @@ class HTTPTransport(Transport):
         to interact with a potentially defunct selector from another thread.
         """
 
-        # Stop the server backend
-        await self.backend.stop()
-
-        import asyncio
-
-        loop_id = id(asyncio.get_running_loop())
-        client = self._clients.pop(loop_id, None)
-        if client and not client.is_closed:
-            await client.aclose()
+        if self._transport_running:
+            await self.backend.stop()
+            self._transport_running = False
+        await self.close_loop_resources()
+        self._clients.clear()
 
     # ------------------------------------------------------------------
     # Authentication & Security
@@ -342,6 +392,17 @@ class HTTPTransport(Transport):
                 else:
                     headers["Authorization"] = f"Bearer {token}"
         return headers
+
+    @staticmethod
+    def _serialize_payload(data: Any) -> Any:
+        """Normalize a request body into JSON-compatible data."""
+        if hasattr(data, "to_json"):
+            return data.to_json()
+        if hasattr(data, "to_dict"):
+            return data.to_dict()
+        if isinstance(data, BaseModel):
+            return data.model_dump()
+        return data
 
     def validate_url(self) -> bool:
         """Ensure the target endpoint utilizes standard web protocols (http/https)."""

--- a/protolink/transport/metrics.py
+++ b/protolink/transport/metrics.py
@@ -1,0 +1,75 @@
+"""Dependency-free transport metrics for health checks and observability."""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import asdict, dataclass
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class TransportMetricsSnapshot:
+    """Immutable counters and latency totals for one transport instance.
+
+    Request and stream counters describe logical operations, while ``retries``
+    counts additional wire attempts. Byte counters measure serialized payloads.
+    ``total_latency_ms`` is cumulative request latency so callers can derive an
+    average without the transport imposing a metrics backend.
+    """
+
+    requests_started: int = 0
+    requests_succeeded: int = 0
+    requests_failed: int = 0
+    retries: int = 0
+    streams_started: int = 0
+    streams_completed: int = 0
+    streams_failed: int = 0
+    active_requests: int = 0
+    active_streams: int = 0
+    bytes_sent: int = 0
+    bytes_received: int = 0
+    total_latency_ms: float = 0.0
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-compatible metrics mapping."""
+        return asdict(self)
+
+
+class TransportMetrics:
+    """Thread-safe mutable recorder backing transport metric snapshots."""
+
+    _FIELDS = tuple(TransportMetricsSnapshot.__dataclass_fields__)
+
+    def __init__(self, *, enabled: bool = True) -> None:
+        self.enabled = enabled
+        self._values: dict[str, int | float] = dict.fromkeys(self._FIELDS, 0)
+        self._lock = threading.Lock()
+
+    def add(self, **values: int | float) -> None:
+        """Atomically add values to known counters."""
+        if not self.enabled:
+            return
+        with self._lock:
+            for name, value in values.items():
+                if name not in self._values:
+                    raise KeyError(f"Unknown transport metric: {name}")
+                self._values[name] += value
+
+    def snapshot(self) -> TransportMetricsSnapshot:
+        """Return a consistent immutable snapshot."""
+        with self._lock:
+            values = self._values.copy()
+        return TransportMetricsSnapshot(
+            requests_started=int(values["requests_started"]),
+            requests_succeeded=int(values["requests_succeeded"]),
+            requests_failed=int(values["requests_failed"]),
+            retries=int(values["retries"]),
+            streams_started=int(values["streams_started"]),
+            streams_completed=int(values["streams_completed"]),
+            streams_failed=int(values["streams_failed"]),
+            active_requests=int(values["active_requests"]),
+            active_streams=int(values["active_streams"]),
+            bytes_sent=int(values["bytes_sent"]),
+            bytes_received=int(values["bytes_received"]),
+            total_latency_ms=float(values["total_latency_ms"]),
+        )

--- a/protolink/transport/runtime_transport.py
+++ b/protolink/transport/runtime_transport.py
@@ -19,7 +19,9 @@ from pydantic import BaseModel
 
 from protolink.client.request_spec import ClientRequestSpec
 from protolink.models import Task
-from protolink.transport.base import Transport
+from protolink.transport.base import Transport, TransportRequestContext
+from protolink.transport.config import TransportCapabilities, TransportConfig
+from protolink.transport.errors import TransportConnectionError, TransportError, TransportRemoteError
 from protolink.types import TransportType
 
 if TYPE_CHECKING:
@@ -51,6 +53,8 @@ class RuntimeTransport(Transport):
     url : str
         URL identifying this transport endpoint. Must use the ``runtime://`` scheme
         (e.g., ``"runtime://alice"``).
+    config : TransportConfig, optional
+        Shared limits, retry, shutdown, idempotency, and metrics settings.
     """
 
     transport_type: ClassVar[TransportType] = "runtime"
@@ -59,15 +63,22 @@ class RuntimeTransport(Transport):
     supports_streaming: ClassVar[bool] = True
     """Indicates whether this transport supports asynchronous streaming."""
 
+    capabilities: ClassVar[TransportCapabilities] = TransportCapabilities(
+        networked=False,
+        streaming=True,
+    )
+
     # Global registry for cross-transport routing
     _registry: ClassVar[dict[str, RuntimeTransport]] = {}
 
-    def __init__(self, url: str) -> None:
+    def __init__(self, url: str, *, config: TransportConfig | None = None) -> None:
         """Initialize the in-memory transport.
 
         Args:
             url: The unique runtime URL for this agent transport endpoint.
+            config: Shared production transport behavior.
         """
+        super().__init__(config=config)
         self._url: str = url
         self._endpoints: dict[tuple[str, str], EndpointSpec] = {}
         self._is_running: bool = False
@@ -127,9 +138,52 @@ class RuntimeTransport(Transport):
             ConnectionError: If the target URI is not registered in the global memory bus.
             RuntimeError: If the target endpoint (method/path) cannot be resolved.
         """
+        context = self.new_request_context(request_spec, data)
+        request_size = self.check_payload_limit({"data": data, "params": params}, kind="request", url=base_url)
+
+        async def operation(attempt: TransportRequestContext) -> Any:
+            try:
+                self._metrics.add(bytes_sent=request_size)
+                result = await self._send_once(
+                    request_spec,
+                    base_url,
+                    data,
+                    params,
+                    idempotency_key=attempt.idempotency_key,
+                )
+            except TransportError:
+                raise
+            except Exception as exc:
+                raise TransportRemoteError(
+                    f"Runtime request failed at {base_url}: {exc}",
+                    url=base_url,
+                    request_id=attempt.request_id,
+                ) from exc
+            response_size = self.check_payload_limit(result, kind="response", url=base_url)
+            self._metrics.add(bytes_received=response_size)
+            return result
+
+        async with self.request_slot():
+            return await self.run_with_retries(request_spec, context, operation)
+
+    async def _send_once(
+        self,
+        request_spec: ClientRequestSpec,
+        base_url: str,
+        data: Any = None,
+        params: dict[str, Any] | None = None,
+        *,
+        idempotency_key: str | None = None,
+    ) -> Any:
+        """Execute one in-process request without retry orchestration."""
+        del params
         target: RuntimeTransport | None = self.get_transport(base_url)
         if not target:
-            raise ConnectionError(f"Failed to connect to agent at {base_url}. Agent transport not found in registry.")
+            raise TransportConnectionError(
+                f"Failed to connect to agent at {base_url}. Agent transport not found in registry.",
+                url=base_url,
+                retryable=True,
+            )
 
         # Resolve the applicable endpoint configuration on the target node
         endpoint_key: tuple[str, str] = (request_spec.method.upper(), request_spec.path)
@@ -141,10 +195,35 @@ class RuntimeTransport(Transport):
             endpoint = target._endpoints.get((request_spec.method.upper(), alt_path))
 
         if not endpoint:
-            raise RuntimeError(
-                f"Agent at {base_url} returned HTTP 404: Endpoint {request_spec.method} {request_spec.path} not found"
+            raise TransportRemoteError(
+                f"Agent at {base_url} returned HTTP 404: Endpoint {request_spec.method} {request_spec.path} not found",
+                url=base_url,
+                status_code=404,
             )
 
+        cache_key = (
+            f"{request_spec.method}:{request_spec.path}:{idempotency_key}" if idempotency_key is not None else None
+        )
+        owns_operation, cached = await target.acquire_idempotent_response(cache_key)
+        if not owns_operation:
+            return cached
+
+        try:
+            async with target.inbound_request_slot():
+                parsed_result = await self._invoke_endpoint(endpoint, data, request_spec)
+        except BaseException as exc:
+            target.abort_idempotent_response(cache_key, exc)
+            raise
+        target.complete_idempotent_response(cache_key, parsed_result)
+        return parsed_result
+
+    async def _invoke_endpoint(
+        self,
+        endpoint: EndpointSpec,
+        data: Any,
+        request_spec: ClientRequestSpec,
+    ) -> Any:
+        """Apply the runtime serialization boundary and invoke one endpoint."""
         # Simulate robust network serialization/deserialization mimicking HTTP transport boundaries
         payload: Any = data
         if payload is not None:
@@ -181,21 +260,22 @@ class RuntimeTransport(Transport):
             result = await result
 
         # Emulate outgoing response serialization using specified JSON parsers
+        parsed_result = result
         if request_spec.response_parser:
             if hasattr(result, "to_dict"):
-                return request_spec.response_parser(result.to_dict())
+                parsed_result = request_spec.response_parser(result.to_dict())
             elif isinstance(result, BaseModel):
-                return request_spec.response_parser(result.model_dump())
+                parsed_result = request_spec.response_parser(result.model_dump())
             elif isinstance(result, dict):
-                return request_spec.response_parser(result)
+                parsed_result = request_spec.response_parser(result)
 
-        return result
+        return parsed_result
 
     # ------------------------------------------------------------------
     # Streaming Support
     # ------------------------------------------------------------------
 
-    async def subscribe(self, base_url: str, task: Task) -> AsyncIterator[dict[str, Any]]:
+    async def subscribe(self, agent_url: str, task: Task) -> AsyncIterator[dict[str, Any]]:
         """Establish a local asynchronous streaming pipeline to a peer agent.
 
         Designed for streaming workloads like real-time agent thought processing, this method
@@ -216,46 +296,64 @@ class RuntimeTransport(Transport):
             ConnectionError: If the target agent is not actively registered.
             RuntimeError: If the resolved endpoint fails to return an `AsyncIterator`.
         """
-        target: RuntimeTransport | None = self.get_transport(base_url)
-        if not target:
-            raise ConnectionError(f"Failed to connect to agent at {base_url}. Agent transport not found in registry.")
+        base_url = agent_url
+        request_size = self.check_payload_limit(task, kind="request", url=base_url)
+        async with self.stream_slot():
+            target: RuntimeTransport | None = self.get_transport(base_url)
+            if not target:
+                raise TransportConnectionError(
+                    f"Failed to connect to agent at {base_url}. Agent transport not found in registry.",
+                    url=base_url,
+                    retryable=True,
+                )
 
         # Resolve an endpoint explicitly designed for streaming
-        stream_endpoints: list[EndpointSpec] = [ep for ep in target._endpoints.values() if ep.streaming]
-        if not stream_endpoints:
+            stream_endpoints: list[EndpointSpec] = [ep for ep in target._endpoints.values() if ep.streaming]
+            if not stream_endpoints:
             # Fallback wrapper enabling non-streaming endpoints to mock a final stream response
-            fallback_spec = ClientRequestSpec(
-                name="task",
-                path="/tasks/",
-                method="POST",
-                request_source="body",
-            )
-            result: Any = await self.send(fallback_spec, base_url, data=task)
-            from protolink.core.events import TaskStatusUpdateEvent
+                fallback_spec = ClientRequestSpec(
+                    name="task",
+                    path="/tasks/",
+                    method="POST",
+                    request_source="body",
+                    idempotent=True,
+                )
+                result: Any = await self.send(fallback_spec, base_url, data=task)
+                from protolink.core.events import TaskStatusUpdateEvent
 
-            yield TaskStatusUpdateEvent(task_id=result.id, new_state="completed", final=True).to_dict()
-            return
+                event = TaskStatusUpdateEvent(task_id=result.id, new_state="completed", final=True).to_dict()
+                event_size = self.check_payload_limit(event, kind="event", url=base_url)
+                self._metrics.add(bytes_sent=request_size, bytes_received=event_size)
+                yield event
+                return
 
-        endpoint: EndpointSpec = stream_endpoints[0]
+            endpoint: EndpointSpec = stream_endpoints[0]
 
         # Emulate boundary validation across streaming task delivery
-        payload: Any = task
-        if endpoint.request_parser:
-            payload = endpoint.request_parser(task.to_dict())
-            if inspect.isawaitable(payload):
-                payload = await payload
+            payload: Any = task
+            if endpoint.request_parser:
+                payload = endpoint.request_parser(task.to_dict())
+                if inspect.isawaitable(payload):
+                    payload = await payload
 
         # Begin generator sequence
-        result = endpoint.handler(payload)
+            result = endpoint.handler(payload)
 
-        if inspect.isawaitable(result):
-            result = await result
+            if inspect.isawaitable(result):
+                result = await result
 
-        if hasattr(result, "__aiter__"):
-            async for event in result:
-                yield event.to_dict() if hasattr(event, "to_dict") else event
-        else:
-            raise RuntimeError("Streaming endpoint handler must return an AsyncIterator")
+            if hasattr(result, "__aiter__"):
+                self._metrics.add(bytes_sent=request_size)
+                async for event in result:
+                    serialized = event.to_dict() if hasattr(event, "to_dict") else event
+                    event_size = self.check_payload_limit(serialized, kind="event", url=base_url)
+                    self._metrics.add(bytes_received=event_size)
+                    yield serialized
+            else:
+                raise TransportRemoteError(
+                    "Streaming endpoint handler must return an AsyncIterator",
+                    url=base_url,
+                )
 
     # ------------------------------------------------------------------
     # Transport Lifecycle
@@ -281,8 +379,11 @@ class RuntimeTransport(Transport):
         singleton dictionary. Once registered, any other agent running in the same Python
         process can instantly route messages to this transport using its `runtime://` URI.
         """
+        if self._is_running:
+            return
         RuntimeTransport._registry[self._url] = self
         self._is_running = True
+        self._transport_running = True
 
     async def stop(self) -> None:
         """Gracefully terminate transport operations and drop from the global registry.
@@ -294,6 +395,7 @@ class RuntimeTransport(Transport):
         RuntimeTransport._registry.pop(self._url, None)
         self._endpoints.clear()
         self._is_running = False
+        self._transport_running = False
 
     # ------------------------------------------------------------------
     # Properties

--- a/protolink/transport/runtime_transport.py
+++ b/protolink/transport/runtime_transport.py
@@ -307,10 +307,10 @@ class RuntimeTransport(Transport):
                     retryable=True,
                 )
 
-        # Resolve an endpoint explicitly designed for streaming
+            # Resolve an endpoint explicitly designed for streaming
             stream_endpoints: list[EndpointSpec] = [ep for ep in target._endpoints.values() if ep.streaming]
             if not stream_endpoints:
-            # Fallback wrapper enabling non-streaming endpoints to mock a final stream response
+                # Fallback wrapper enabling non-streaming endpoints to mock a final stream response
                 fallback_spec = ClientRequestSpec(
                     name="task",
                     path="/tasks/",
@@ -329,14 +329,14 @@ class RuntimeTransport(Transport):
 
             endpoint: EndpointSpec = stream_endpoints[0]
 
-        # Emulate boundary validation across streaming task delivery
+            # Emulate boundary validation across streaming task delivery
             payload: Any = task
             if endpoint.request_parser:
                 payload = endpoint.request_parser(task.to_dict())
                 if inspect.isawaitable(payload):
                     payload = await payload
 
-        # Begin generator sequence
+            # Begin generator sequence
             result = endpoint.handler(payload)
 
             if inspect.isawaitable(result):

--- a/protolink/transport/sse_jsonrpc_transport.py
+++ b/protolink/transport/sse_jsonrpc_transport.py
@@ -84,13 +84,13 @@ class SSEJSONRPCTransport(HTTPTransport):
                     async for line in response.aiter_lines():
                         if line == "":
                             result, final = self._parse_event(event_lines, agent_url, request_id)
+                            event_lines = []
                             if result is not None:
                                 event_size = self.check_payload_limit(result, kind="event", url=url)
                                 self._metrics.add(bytes_received=event_size)
                                 yield result
                             if final:
                                 break
-                            event_lines = []
                             continue
                         if line.startswith("data:"):
                             event_lines.append(line[5:].strip())

--- a/protolink/transport/sse_jsonrpc_transport.py
+++ b/protolink/transport/sse_jsonrpc_transport.py
@@ -3,12 +3,19 @@
 from __future__ import annotations
 
 import json
-import uuid
 from collections.abc import AsyncIterator
 from typing import Any, ClassVar
 
 import httpx
 
+from protolink.client.request_spec import ClientRequestSpec
+from protolink.transport.config import TransportCapabilities
+from protolink.transport.errors import (
+    TransportConnectionError,
+    TransportProtocolError,
+    TransportRemoteError,
+    TransportTimeoutError,
+)
 from protolink.transport.http_transport import HTTPTransport
 from protolink.types import TransportType
 
@@ -24,6 +31,11 @@ class SSEJSONRPCTransport(HTTPTransport):
 
     transport_type: ClassVar[TransportType] = "sse"
     supports_streaming: ClassVar[bool] = True
+    capabilities: ClassVar[TransportCapabilities] = TransportCapabilities(
+        streaming=True,
+        tls=True,
+        persistent_connections=True,
+    )
 
     async def subscribe(self, agent_url: str, task: Any) -> AsyncIterator[Any]:
         """Stream events from a remote agent's ``/tasks/stream`` endpoint.
@@ -37,8 +49,16 @@ class SSEJSONRPCTransport(HTTPTransport):
         if self.authenticator and self.credentials and not self.security_context:
             await self.authenticate(self.credentials)
 
+        request_spec = ClientRequestSpec(
+            name="task_stream",
+            path="/tasks/stream",
+            method="POST",
+            request_source="body",
+            idempotent=False,
+        )
+        context = self.new_request_context(request_spec, task)
         client = await self._ensure_client()
-        request_id = uuid.uuid4().hex
+        request_id = context.request_id
         headers = {
             **self._build_headers(),
             "Accept": "text/event-stream",
@@ -47,39 +67,61 @@ class SSEJSONRPCTransport(HTTPTransport):
         }
         payload = self._serialize_payload(task)
         url = f"{agent_url.rstrip('/')}/tasks/stream"
+        request_size = self.check_payload_limit(payload, kind="request", url=url)
 
-        try:
-            async with client.stream(
-                "POST",
-                url,
-                json=payload,
-                headers=headers,
-                timeout=self._timeout,
-            ) as response:
-                response.raise_for_status()
-                event_lines: list[str] = []
-                async for line in response.aiter_lines():
-                    if line == "":
-                        result, final = self._parse_event(event_lines, agent_url, request_id)
-                        if result is not None:
-                            yield result
-                        if final:
-                            break
-                        event_lines = []
-                        continue
-                    if line.startswith("data:"):
-                        event_lines.append(line[5:].strip())
+        async with self.stream_slot():
+            try:
+                async with client.stream(
+                    "POST",
+                    url,
+                    json=payload,
+                    headers=headers,
+                    timeout=self._timeout,
+                ) as response:
+                    response.raise_for_status()
+                    self._metrics.add(bytes_sent=request_size)
+                    event_lines: list[str] = []
+                    async for line in response.aiter_lines():
+                        if line == "":
+                            result, final = self._parse_event(event_lines, agent_url, request_id)
+                            if result is not None:
+                                event_size = self.check_payload_limit(result, kind="event", url=url)
+                                self._metrics.add(bytes_received=event_size)
+                                yield result
+                            if final:
+                                break
+                            event_lines = []
+                            continue
+                        if line.startswith("data:"):
+                            event_lines.append(line[5:].strip())
 
-                result, _final = self._parse_event(event_lines, agent_url, request_id)
-                if result is not None:
-                    yield result
-        except httpx.ConnectError as exc:
-            raise ConnectionError(
-                f"Failed to connect to agent at {agent_url}. Make sure the agent is running and accessible."
-            ) from exc
-        except httpx.HTTPStatusError as exc:
-            status_code = exc.response.status_code
-            raise RuntimeError(f"Agent at {agent_url} returned HTTP {status_code}: {exc.response.text}") from exc
+                    result, _final = self._parse_event(event_lines, agent_url, request_id)
+                    if result is not None:
+                        event_size = self.check_payload_limit(result, kind="event", url=url)
+                        self._metrics.add(bytes_received=event_size)
+                        yield result
+            except httpx.TimeoutException as exc:
+                raise TransportTimeoutError(
+                    f"SSE stream from {agent_url} timed out",
+                    url=url,
+                    request_id=request_id,
+                    retryable=True,
+                ) from exc
+            except httpx.ConnectError as exc:
+                raise TransportConnectionError(
+                    f"Failed to connect to agent at {agent_url}. Make sure the agent is running and accessible.",
+                    url=url,
+                    request_id=request_id,
+                    retryable=True,
+                ) from exc
+            except httpx.HTTPStatusError as exc:
+                status_code = exc.response.status_code
+                raise TransportRemoteError(
+                    f"Agent at {agent_url} returned HTTP {status_code}: {exc.response.text}",
+                    url=url,
+                    request_id=request_id,
+                    status_code=status_code,
+                ) from exc
 
     def _parse_event(self, event_lines: list[str], agent_url: str, request_id: str) -> tuple[Any | None, bool]:
         """Parse one SSE event block into ``(result, final)``.
@@ -95,24 +137,37 @@ class SSEJSONRPCTransport(HTTPTransport):
         try:
             message = json.loads(raw)
         except json.JSONDecodeError as exc:
-            raise RuntimeError(f"Invalid SSE JSON-RPC event from {agent_url}: {raw!r}") from exc
+            raise TransportProtocolError(
+                f"Invalid SSE JSON-RPC event from {agent_url}: {raw!r}",
+                url=agent_url,
+                request_id=request_id,
+            ) from exc
 
         message_id = message.get("id")
         if message_id not in {None, request_id}:
-            raise RuntimeError(f"Mismatched SSE JSON-RPC event id from {agent_url}: {message_id}")
+            raise TransportProtocolError(
+                f"Mismatched SSE JSON-RPC event id from {agent_url}: {message_id}",
+                url=agent_url,
+                request_id=request_id,
+            )
 
         if not message.get("ok", False):
             error = message.get("error") or {}
-            raise RuntimeError(f"SSE JSON-RPC stream failed at {agent_url}: {error}")
+            raise TransportRemoteError(
+                f"SSE JSON-RPC stream failed at {agent_url}: {error}",
+                url=agent_url,
+                request_id=request_id,
+            )
 
         return message.get("result"), bool(message.get("final", False))
 
-    def _serialize_payload(self, payload: Any) -> Any:
+    @staticmethod
+    def _serialize_payload(data: Any) -> Any:
         """Convert Protolink domain objects into JSON-serializable payloads."""
-        if hasattr(payload, "to_json"):
-            return payload.to_json()
-        if hasattr(payload, "to_dict"):
-            return payload.to_dict()
-        if hasattr(payload, "model_dump"):
-            return payload.model_dump()
-        return payload
+        if hasattr(data, "to_json"):
+            return data.to_json()
+        if hasattr(data, "to_dict"):
+            return data.to_dict()
+        if hasattr(data, "model_dump"):
+            return data.model_dump()
+        return data

--- a/protolink/transport/websocket_transport.py
+++ b/protolink/transport/websocket_transport.py
@@ -263,6 +263,7 @@ class WebSocketTransport(Transport):
                     await conn.send(json.dumps(payload))
                     raw = await asyncio.wait_for(conn.recv(), timeout=self._timeout)
                 except TimeoutError as exc:
+                    await self._discard_client_connection(loop_key, conn)
                     raise TransportTimeoutError(
                         f"WebSocket request to {base_url} timed out",
                         url=base_url,
@@ -270,18 +271,23 @@ class WebSocketTransport(Transport):
                         retryable=True,
                     ) from exc
                 except ConnectionClosed as exc:
-                    self._client_conns.pop(loop_key, None)
-                    self.discard_loop_resource(("websocket", loop_key))
+                    await self._discard_client_connection(loop_key, conn)
                     raise TransportConnectionError(
                         f"WebSocket connection closed while talking to {base_url}",
                         url=base_url,
                         request_id=attempt.request_id,
                         retryable=True,
                     ) from exc
-
-            response = self._decode_response(raw, base_url, attempt.request_id)
-            result = self._unwrap_response(response, base_url, attempt.request_id)
-            response_size = self.check_payload_limit(result, kind="response", url=base_url)
+                except asyncio.CancelledError:
+                    await self._discard_client_connection(loop_key, conn)
+                    raise
+                try:
+                    response = self._decode_response(raw, base_url, attempt.request_id)
+                    result = self._unwrap_response(response, base_url, attempt.request_id)
+                    response_size = self.check_payload_limit(result, kind="response", url=base_url)
+                except TransportProtocolError:
+                    await self._discard_client_connection(loop_key, conn)
+                    raise
             self._metrics.add(bytes_received=response_size)
             return request_spec.response_parser(result) if request_spec.response_parser else result
 
@@ -326,6 +332,7 @@ class WebSocketTransport(Transport):
                     loop_key,
                     request_id=message_id,
                 )
+                stream_complete = False
                 try:
                     self._metrics.add(bytes_sent=request_size)
                     await conn.send(json.dumps(payload))
@@ -338,6 +345,7 @@ class WebSocketTransport(Transport):
                             self._metrics.add(bytes_received=event_size)
                             yield result
                         if msg.get("final", False):
+                            stream_complete = True
                             break
                 except TimeoutError as exc:
                     raise TransportTimeoutError(
@@ -347,14 +355,15 @@ class WebSocketTransport(Transport):
                         retryable=True,
                     ) from exc
                 except ConnectionClosed as exc:
-                    self._client_conns.pop(loop_key, None)
-                    self.discard_loop_resource(("websocket", loop_key))
                     raise TransportConnectionError(
                         f"WebSocket connection closed while streaming from {agent_url}",
                         url=agent_url,
                         request_id=message_id,
                         retryable=True,
                     ) from exc
+                finally:
+                    if not stream_complete:
+                        await self._discard_client_connection(loop_key, conn)
 
     async def _ensure_client_connection(
         self,
@@ -400,6 +409,16 @@ class WebSocketTransport(Transport):
         self._client_conns[loop_key] = conn
         self.register_loop_resource(("websocket", loop_key), conn.close)
         return conn
+
+    async def _discard_client_connection(self, loop_key: str, conn: Any) -> None:
+        """Close a pooled connection that can no longer provide aligned frames."""
+        if self._client_conns.get(loop_key) is conn:
+            self._client_conns.pop(loop_key, None)
+        self.discard_loop_resource(("websocket", loop_key))
+        try:
+            await conn.close()
+        except Exception:
+            pass
 
     def _build_request_payload(
         self,
@@ -615,7 +634,11 @@ class WebSocketTransport(Transport):
                     response = {"id": request_id, "ok": True, "result": self._serialize_result(result)}
                     self.check_payload_limit(response, kind="response", url=self._url)
                     self.complete_idempotent_response(idempotency_key, response)
+                except asyncio.CancelledError as exc:
+                    self.abort_idempotent_response(idempotency_key, exc)
+                    raise
                 except Exception as e:
+                    self.abort_idempotent_response(idempotency_key, e)
                     response = {
                         "id": req.get("id") if isinstance(req, dict) else None,
                         "ok": False,
@@ -624,7 +647,6 @@ class WebSocketTransport(Transport):
 
                     if isinstance(req, dict) and req.get("path") == "/tasks/stream":
                         response["final"] = True
-                    self.complete_idempotent_response(idempotency_key, response)
 
                 await websocket.send(json.dumps(response))
         except ConnectionClosed:

--- a/protolink/transport/websocket_transport.py
+++ b/protolink/transport/websocket_transport.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import inspect
 import json
-import uuid
 from collections.abc import AsyncIterator
 from typing import Any, ClassVar
 from urllib.parse import urlparse
@@ -13,7 +12,14 @@ from protolink.security.auth import Authenticator
 from protolink.security.tls import TLSConfig
 from protolink.server.endpoint_handler import EndpointSpec
 from protolink.transport._streaming import is_stream_terminal_event
-from protolink.transport.base import Transport
+from protolink.transport.base import Transport, TransportRequestContext
+from protolink.transport.config import TransportCapabilities, TransportConfig
+from protolink.transport.errors import (
+    TransportConnectionError,
+    TransportProtocolError,
+    TransportRemoteError,
+    TransportTimeoutError,
+)
 from protolink.types import TransportType
 from protolink.utils.inspect import is_async_callable
 from protolink.utils.serialization import Serializer
@@ -55,10 +61,17 @@ class WebSocketTransport(Transport):
         credentials: Optional credentials for outbound authentication.
         tls: Optional certificate and trust configuration used by ``wss://``
             servers and clients.
+        config: Shared limits, retry, keepalive, shutdown, idempotency, and metrics settings.
     """
 
     transport_type: ClassVar[TransportType] = "websocket"
     supports_streaming: ClassVar[bool] = True
+    capabilities: ClassVar[TransportCapabilities] = TransportCapabilities(
+        streaming=True,
+        tls=True,
+        bidirectional=True,
+        persistent_connections=True,
+    )
 
     def __init__(
         self,
@@ -68,8 +81,14 @@ class WebSocketTransport(Transport):
         credentials: str | None = None,
         *,
         tls: TLSConfig | None = None,
+        config: TransportConfig | None = None,
     ) -> None:
-        """Initialize a loop-safe WebSocket transport."""
+        """Initialize a loop-safe WebSocket transport.
+
+        Client connections are created lazily per event loop and closed on
+        their owning loops during shutdown.
+        """
+        super().__init__(config=config)
         self._url: str = url
         self._timeout: float = timeout
         self.authenticator: Authenticator | None = authenticator
@@ -117,12 +136,18 @@ class WebSocketTransport(Transport):
         lifecycle. Once bound to the designated port, all inbound TCP connections are immediately
         funneled directly into the ``_handle_connection`` multiplexer.
         """
+        if self._transport_running:
+            return
         host, port = self._get_host_port(self._url)
         if not host or not port:
             raise ValueError(f"Invalid URL: {self._url}. Missing host or port.")
 
         kwargs: dict[str, Any] = {
-            "close_timeout": 3.0,
+            "close_timeout": self.config.shutdown_timeout,
+            "max_size": self.config.limits.max_request_bytes,
+            "max_queue": self.config.limits.max_concurrent_requests,
+            "ping_interval": self.config.keepalive_interval,
+            "ping_timeout": self.config.keepalive_timeout,
         }
         if self.authenticator:
             kwargs["process_request"] = self._process_request
@@ -138,6 +163,7 @@ class WebSocketTransport(Transport):
             port=port,
             **kwargs,
         )
+        self._transport_running = True
 
     async def _process_request(self, path: str, request_headers: Any) -> Any:
         """Authenticate incoming websocket handshake requests."""
@@ -186,11 +212,7 @@ class WebSocketTransport(Transport):
 
     async def stop(self) -> None:
         """Stop the WebSocket server and close any cached client connections."""
-        for conn in list(self._client_conns.values()):
-            try:
-                await conn.close()
-            except Exception:
-                pass
+        await self.close_loop_resources()
         self._client_conns.clear()
         self._client_locks.clear()
 
@@ -198,6 +220,7 @@ class WebSocketTransport(Transport):
             self._server.close()
             await self._server.wait_closed()
             self._server = None
+        self._transport_running = False
 
     # ------------------------------------------------------------------
     # Client
@@ -220,59 +243,50 @@ class WebSocketTransport(Transport):
         This design facilitates transparent, bi-directional communication while appearing identical
         to standard HTTP request/response lifecycles to the developer.
         """
-        if self.authenticator and self.credentials and not self.security_context:
-            await self.authenticate(self.credentials)
+        context = self.new_request_context(request_spec, data)
 
-        message_id = uuid.uuid4().hex
+        async def operation(attempt: TransportRequestContext) -> Any:
+            if self.authenticator and self.credentials and not self.security_context:
+                await self.authenticate(self.credentials)
+            payload = self._build_request_payload(request_spec, data, params, attempt)
+            request_size = self.check_payload_limit(payload, kind="request", url=base_url)
+            loop_key = f"{base_url}_{id(asyncio.get_running_loop())}_{request_spec.channel}"
+            lock = self._client_locks.setdefault(loop_key, asyncio.Lock())
+            async with lock:
+                conn = await self._ensure_client_connection(
+                    base_url,
+                    loop_key,
+                    request_id=attempt.request_id,
+                )
+                try:
+                    self._metrics.add(bytes_sent=request_size)
+                    await conn.send(json.dumps(payload))
+                    raw = await asyncio.wait_for(conn.recv(), timeout=self._timeout)
+                except TimeoutError as exc:
+                    raise TransportTimeoutError(
+                        f"WebSocket request to {base_url} timed out",
+                        url=base_url,
+                        request_id=attempt.request_id,
+                        retryable=True,
+                    ) from exc
+                except ConnectionClosed as exc:
+                    self._client_conns.pop(loop_key, None)
+                    self.discard_loop_resource(("websocket", loop_key))
+                    raise TransportConnectionError(
+                        f"WebSocket connection closed while talking to {base_url}",
+                        url=base_url,
+                        request_id=attempt.request_id,
+                        retryable=True,
+                    ) from exc
 
-        payload: dict[str, Any] = {
-            "id": message_id,
-            "method": request_spec.method,
-            "path": request_spec.path,
-        }
+            response = self._decode_response(raw, base_url, attempt.request_id)
+            result = self._unwrap_response(response, base_url, attempt.request_id)
+            response_size = self.check_payload_limit(result, kind="response", url=base_url)
+            self._metrics.add(bytes_received=response_size)
+            return request_spec.response_parser(result) if request_spec.response_parser else result
 
-        if request_spec.request_source == "body" and data is not None:
-            payload["data"] = self._serialize_result(data)
-        elif request_spec.request_source == "query_params" and data is not None:
-            if isinstance(data, dict):
-                payload["params"] = data
-            else:
-                payload["params"] = {"data": str(data)}
-
-        if params:
-            payload.setdefault("params", {})
-            payload["params"].update(params)
-
-        loop_key = f"{base_url}_{id(asyncio.get_running_loop())}_{request_spec.channel}"
-        lock = self._client_locks.setdefault(loop_key, asyncio.Lock())
-        async with lock:
-            conn = await self._ensure_client_connection(base_url, loop_key)
-            try:
-                await conn.send(json.dumps(payload))
-                raw = await asyncio.wait_for(conn.recv(), timeout=self._timeout)
-            except ConnectionClosed as e:
-                self._client_conns.pop(loop_key, None)
-                raise ConnectionError(f"WebSocket connection closed while talking to {base_url}") from e
-
-        if isinstance(raw, (bytes, bytearray)):
-            raw = raw.decode("utf-8", errors="replace")
-
-        try:
-            response = json.loads(raw)
-        except Exception as e:
-            raise RuntimeError(f"Invalid JSON response from {base_url}: {raw!r}") from e
-
-        if response.get("id") != message_id:
-            raise RuntimeError(f"Mismatched response id from {base_url}: {response.get('id')}")
-
-        if not response.get("ok", False):
-            err = response.get("error") or {}
-            raise RuntimeError(f"WebSocket request failed at {base_url}: {err}")
-
-        result = response.get("result")
-        if request_spec.response_parser:
-            return request_spec.response_parser(result)
-        return result
+        async with self.request_slot():
+            return await self.run_with_retries(request_spec, context, operation)
 
     async def subscribe(self, agent_url: str, task: Any) -> AsyncIterator[Any]:
         """Establish an asynchronous streaming pipeline over a persistent WebSocket connection.
@@ -286,7 +300,14 @@ class WebSocketTransport(Transport):
         if self.authenticator and self.credentials and not self.security_context:
             await self.authenticate(self.credentials)
 
-        message_id = uuid.uuid4().hex
+        request_spec = ClientRequestSpec(
+            name="task_stream",
+            path="/tasks/stream",
+            method="POST",
+            request_source="body",
+        )
+        context = self.new_request_context(request_spec, task)
+        message_id = context.request_id
 
         payload: dict[str, Any] = {
             "id": message_id,
@@ -295,40 +316,53 @@ class WebSocketTransport(Transport):
             "data": self._serialize_result(task),
         }
 
-        loop_key = f"{agent_url}_{id(asyncio.get_running_loop())}_default"
-        lock = self._client_locks.setdefault(loop_key, asyncio.Lock())
-        async with lock:
-            conn = await self._ensure_client_connection(agent_url, loop_key)
-            try:
-                await conn.send(json.dumps(payload))
-                while True:
-                    raw = await asyncio.wait_for(conn.recv(), timeout=self._timeout)
-                    if isinstance(raw, (bytes, bytearray)):
-                        raw = raw.decode("utf-8", errors="replace")
+        request_size = self.check_payload_limit(payload, kind="request", url=agent_url)
+        async with self.stream_slot():
+            loop_key = f"{agent_url}_{id(asyncio.get_running_loop())}_default"
+            lock = self._client_locks.setdefault(loop_key, asyncio.Lock())
+            async with lock:
+                conn = await self._ensure_client_connection(
+                    agent_url,
+                    loop_key,
+                    request_id=message_id,
+                )
+                try:
+                    self._metrics.add(bytes_sent=request_size)
+                    await conn.send(json.dumps(payload))
+                    while True:
+                        raw = await asyncio.wait_for(conn.recv(), timeout=self._timeout)
+                        msg = self._decode_response(raw, agent_url, message_id)
+                        result = self._unwrap_response(msg, agent_url, message_id, operation="stream")
+                        if result is not None:
+                            event_size = self.check_payload_limit(result, kind="event", url=agent_url)
+                            self._metrics.add(bytes_received=event_size)
+                            yield result
+                        if msg.get("final", False):
+                            break
+                except TimeoutError as exc:
+                    raise TransportTimeoutError(
+                        f"WebSocket stream from {agent_url} timed out",
+                        url=agent_url,
+                        request_id=message_id,
+                        retryable=True,
+                    ) from exc
+                except ConnectionClosed as exc:
+                    self._client_conns.pop(loop_key, None)
+                    self.discard_loop_resource(("websocket", loop_key))
+                    raise TransportConnectionError(
+                        f"WebSocket connection closed while streaming from {agent_url}",
+                        url=agent_url,
+                        request_id=message_id,
+                        retryable=True,
+                    ) from exc
 
-                    try:
-                        msg = json.loads(raw)
-                    except Exception as e:
-                        raise RuntimeError(f"Invalid JSON stream message from {agent_url}: {raw!r}") from e
-
-                    if msg.get("id") != message_id:
-                        raise RuntimeError(f"Mismatched stream id from {agent_url}: {msg.get('id')}")
-
-                    if not msg.get("ok", False):
-                        err = msg.get("error") or {}
-                        raise RuntimeError(f"WebSocket stream failed at {agent_url}: {err}")
-
-                    result = msg.get("result")
-                    if result is not None:
-                        yield result
-
-                    if msg.get("final", False):
-                        break
-            except ConnectionClosed as e:
-                self._client_conns.pop(loop_key, None)
-                raise ConnectionError(f"WebSocket connection closed while streaming from {agent_url}") from e
-
-    async def _ensure_client_connection(self, base_url: str, loop_key: str) -> Any:
+    async def _ensure_client_connection(
+        self,
+        base_url: str,
+        loop_key: str,
+        *,
+        request_id: str | None = None,
+    ) -> Any:
         """Get or create a cached client WebSocket connection for ``base_url``.
 
         This method utilizes a ``loop_key`` (incorporating the current ``asyncio`` event
@@ -342,15 +376,98 @@ class WebSocketTransport(Transport):
             return existing
 
         headers = self._build_headers()
-        connect_kwargs: dict[str, Any] = {}
+        connect_kwargs: dict[str, Any] = {
+            "close_timeout": self.config.shutdown_timeout,
+            "max_size": max(self.config.limits.max_response_bytes, self.config.limits.max_event_bytes),
+            "max_queue": self.config.limits.max_concurrent_requests,
+            "ping_interval": self.config.keepalive_interval,
+            "ping_timeout": self.config.keepalive_timeout,
+        }
         if urlparse(base_url).scheme.lower() == "wss" and self.tls is not None:
             connect_kwargs["ssl"] = self.tls.create_client_context()
         try:
-            conn = await websockets.connect(base_url, additional_headers=headers, **connect_kwargs)
-        except TypeError:
-            conn = await websockets.connect(base_url, extra_headers=headers, **connect_kwargs)
+            try:
+                conn = await websockets.connect(base_url, additional_headers=headers, **connect_kwargs)
+            except TypeError:
+                conn = await websockets.connect(base_url, extra_headers=headers, **connect_kwargs)
+        except (OSError, TimeoutError, ConnectionClosed) as exc:
+            raise TransportConnectionError(
+                f"Failed to connect to WebSocket agent at {base_url}",
+                url=base_url,
+                request_id=request_id,
+                retryable=True,
+            ) from exc
         self._client_conns[loop_key] = conn
+        self.register_loop_resource(("websocket", loop_key), conn.close)
         return conn
+
+    def _build_request_payload(
+        self,
+        request_spec: ClientRequestSpec,
+        data: Any,
+        params: dict[str, Any] | None,
+        context: TransportRequestContext,
+    ) -> dict[str, Any]:
+        """Build a correlated JSON request envelope."""
+        payload: dict[str, Any] = {
+            "id": context.request_id,
+            "method": request_spec.method,
+            "path": request_spec.path,
+        }
+        if context.idempotency_key:
+            payload["idempotency_key"] = context.idempotency_key
+        if request_spec.request_source == "body" and data is not None:
+            payload["data"] = self._serialize_result(data)
+        elif request_spec.request_source == "query_params" and data is not None:
+            payload["params"] = data if isinstance(data, dict) else {"data": str(data)}
+        if params:
+            payload.setdefault("params", {})
+            payload["params"].update(params)
+        return payload
+
+    def _decode_response(self, raw: Any, base_url: str, request_id: str) -> dict[str, Any]:
+        """Decode and validate one WebSocket response frame."""
+        if isinstance(raw, (bytes, bytearray)):
+            raw = raw.decode("utf-8", errors="replace")
+        try:
+            response = json.loads(raw)
+        except (json.JSONDecodeError, TypeError) as exc:
+            raise TransportProtocolError(
+                f"Invalid JSON response from {base_url}: {raw!r}",
+                url=base_url,
+                request_id=request_id,
+            ) from exc
+        if not isinstance(response, dict):
+            raise TransportProtocolError(
+                f"WebSocket response from {base_url} must be a JSON object",
+                url=base_url,
+                request_id=request_id,
+            )
+        return response
+
+    def _unwrap_response(
+        self,
+        response: dict[str, Any],
+        base_url: str,
+        request_id: str,
+        *,
+        operation: str = "request",
+    ) -> Any:
+        """Validate correlation and unwrap a WebSocket response envelope."""
+        if response.get("id") != request_id:
+            raise TransportProtocolError(
+                f"Mismatched WebSocket {operation} id from {base_url}: {response.get('id')}",
+                url=base_url,
+                request_id=request_id,
+            )
+        if not response.get("ok", False):
+            error = response.get("error") or {}
+            raise TransportRemoteError(
+                f"WebSocket {operation} failed at {base_url}: {error}",
+                url=base_url,
+                request_id=request_id,
+            )
+        return response.get("result")
 
     @staticmethod
     def _connection_is_open(conn: Any) -> bool:
@@ -432,10 +549,12 @@ class WebSocketTransport(Transport):
             async for raw in websocket:
                 response: dict[str, Any]
                 req: Any = None
+                idempotency_key: str | None = None
                 try:
                     if isinstance(raw, (bytes, bytearray)):
                         raw = raw.decode("utf-8", errors="replace")
                     req = json.loads(raw)
+                    self.check_payload_limit(req, kind="request", url=self._url)
                     request_id = req.get("id")
                     method = str(req.get("method")).upper()
                     path = req.get("path")
@@ -446,6 +565,18 @@ class WebSocketTransport(Transport):
                     ep = self._endpoints.get((method, path))
                     if ep is None:
                         raise ValueError(f"No endpoint registered for {method} {path}")
+
+                    raw_idempotency_key = req.get("idempotency_key")
+                    idempotency_key = f"{method}:{path}:{raw_idempotency_key}" if raw_idempotency_key else None
+                    if ep.mode != "stream" and not ep.streaming:
+                        owns_operation, cached = await self.acquire_idempotent_response(idempotency_key)
+                        if not owns_operation:
+                            if not isinstance(cached, dict):
+                                raise TypeError("Cached WebSocket response must be a mapping")
+                            cached_response = cached.copy()
+                            cached_response["id"] = request_id
+                            await websocket.send(json.dumps(cached_response))
+                            continue
 
                     if ep.request_source == "body":
                         payload = req.get("data")
@@ -466,53 +597,24 @@ class WebSocketTransport(Transport):
                     handler_is_async = is_async_callable(ep.handler)
 
                     if ep.mode == "stream" or ep.streaming:
-                        if ep.request_source != "none" and payload is not None:
-                            stream_obj = ep.handler(handler_input)
-                        else:
-                            stream_obj = ep.handler()
-
-                        if inspect.isawaitable(stream_obj):
-                            stream_obj = await stream_obj
-
-                        if not hasattr(stream_obj, "__aiter__"):
-                            raise TypeError("Streaming handler must return an async iterator")
-
-                        sent_final = False
-                        async for event in stream_obj:
-                            event_payload = self._serialize_result(event)
-                            event_final = False
-                            if isinstance(event_payload, dict):
-                                event_final = bool(event_payload.get("final", False))
-                            stream_final = is_stream_terminal_event(event_payload, event_final=event_final)
-                            await websocket.send(
-                                json.dumps(
-                                    {
-                                        "id": request_id,
-                                        "ok": True,
-                                        "result": event_payload,
-                                        "final": stream_final,
-                                        "stream": True,
-                                    }
-                                )
-                            )
-                            if stream_final:
-                                sent_final = True
-                                break
-
-                        if not sent_final:
-                            await websocket.send(
-                                json.dumps(
-                                    {"id": request_id, "ok": True, "result": None, "final": True, "stream": True}
-                                )
-                            )
+                        await self._send_stream_response(
+                            websocket,
+                            ep,
+                            payload,
+                            handler_input,
+                            request_id,
+                        )
                         continue
 
-                    if ep.request_source != "none" and payload is not None:
-                        result = await ep.handler(handler_input) if handler_is_async else ep.handler(handler_input)
-                    else:
-                        result = await ep.handler() if handler_is_async else ep.handler()
+                    async with self.inbound_request_slot():
+                        if ep.request_source != "none" and payload is not None:
+                            result = await ep.handler(handler_input) if handler_is_async else ep.handler(handler_input)
+                        else:
+                            result = await ep.handler() if handler_is_async else ep.handler()
 
                     response = {"id": request_id, "ok": True, "result": self._serialize_result(result)}
+                    self.check_payload_limit(response, kind="response", url=self._url)
+                    self.complete_idempotent_response(idempotency_key, response)
                 except Exception as e:
                     response = {
                         "id": req.get("id") if isinstance(req, dict) else None,
@@ -522,10 +624,57 @@ class WebSocketTransport(Transport):
 
                     if isinstance(req, dict) and req.get("path") == "/tasks/stream":
                         response["final"] = True
+                    self.complete_idempotent_response(idempotency_key, response)
 
                 await websocket.send(json.dumps(response))
         except ConnectionClosed:
             pass
+
+    async def _send_stream_response(
+        self,
+        websocket: Any,
+        endpoint: EndpointSpec,
+        payload: Any,
+        handler_input: Any,
+        request_id: str,
+    ) -> None:
+        """Run one bounded server stream and emit correlated envelopes."""
+        async with self.stream_slot():
+            if endpoint.request_source != "none" and payload is not None:
+                stream_obj = endpoint.handler(handler_input)
+            else:
+                stream_obj = endpoint.handler()
+
+            if inspect.isawaitable(stream_obj):
+                stream_obj = await stream_obj
+            if not hasattr(stream_obj, "__aiter__"):
+                raise TypeError("Streaming handler must return an async iterator")
+
+            sent_final = False
+            async for event in stream_obj:
+                event_payload = self._serialize_result(event)
+                self.check_payload_limit(event_payload, kind="event", url=self._url)
+                event_final = bool(event_payload.get("final", False)) if isinstance(event_payload, dict) else False
+                stream_final = is_stream_terminal_event(event_payload, event_final=event_final)
+                await websocket.send(
+                    json.dumps(
+                        {
+                            "id": request_id,
+                            "ok": True,
+                            "result": event_payload,
+                            "final": stream_final,
+                            "stream": True,
+                        }
+                    )
+                )
+                if stream_final:
+                    sent_final = True
+                    break
+
+            if not sent_final:
+                await websocket.send(
+                    json.dumps({"id": request_id, "ok": True, "result": None, "final": True, "stream": True})
+                )
 
     def _serialize_result(self, result: Any) -> Any:
         """Recursively normalize complex data models into JSON-safe structures.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,8 @@ possibly-unresolved-reference = "warn"
 allowed-unresolved-imports = [
     "anthropic.**",
     "google.genai.**",
+    "grpc_health.**",
+    "grpc_reflection.**",
     "huggingface_hub.**",
     "llama_cpp.**",
     "mcp.**",
@@ -63,6 +65,8 @@ http = [
 
 grpc = [
     "grpcio>=1.76.0",
+    "grpcio-health-checking>=1.76.0",
+    "grpcio-reflection>=1.76.0",
 ]
 
 llms = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,6 +145,7 @@ build = [
 testpaths = ["tests"]
 python_files = "test_*.py"
 addopts = "-v"
+asyncio_default_test_loop_scope = "module"
 filterwarnings = [
     "ignore::DeprecationWarning:websockets.legacy.*:",
     "ignore::DeprecationWarning:uvicorn.protocols.websockets.websockets_impl.*:",

--- a/tests/test_run_store.py
+++ b/tests/test_run_store.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
+import sqlite3
+
+import pytest
+
 from protolink import RunContext, RunEvent, RunReport, SQLiteRunStore, Task, TaskState
+from protolink.storage import SQLiteStorage
 
 
 def test_sqlite_run_store_persists_task_snapshots_and_reports(tmp_path) -> None:
@@ -45,3 +50,40 @@ def test_sqlite_run_store_persists_task_snapshots_and_reports(tmp_path) -> None:
     assert loaded_report.context is not None
     assert loaded_report.context.session_id == "session-store"
     assert listed_reports[0].metadata == {"suite": "unit"}
+
+
+def test_sqlite_stores_close_every_short_lived_connection(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """SQLite adapters should never depend on garbage collection to close handles."""
+    run_connections: list[sqlite3.Connection] = []
+    original_run_connect = SQLiteRunStore._connect
+
+    def tracked_run_connect(store: SQLiteRunStore) -> sqlite3.Connection:
+        connection = original_run_connect(store)
+        run_connections.append(connection)
+        return connection
+
+    monkeypatch.setattr(SQLiteRunStore, "_connect", tracked_run_connect)
+    run_store = SQLiteRunStore(tmp_path / "runs.db")
+    task = Task.create_infer(prompt="close connections")
+    run_store.save_task(task)
+    assert run_store.get_task(task.id) is not None
+    assert run_store.list_task_records()
+    run_store.delete_task(task.id)
+
+    storage_connections: list[sqlite3.Connection] = []
+    original_storage_connect = sqlite3.connect
+
+    def tracked_storage_connect(*args, **kwargs) -> sqlite3.Connection:
+        connection = original_storage_connect(*args, **kwargs)
+        storage_connections.append(connection)
+        return connection
+
+    monkeypatch.setattr("protolink.storage.sqlite.sqlite3.connect", tracked_storage_connect)
+    storage = SQLiteStorage(db_path=str(tmp_path / "storage.db"))
+    storage.save({"ready": True})
+    assert storage.load() == {"ready": True}
+    storage.delete()
+
+    for connection in [*run_connections, *storage_connections]:
+        with pytest.raises(sqlite3.ProgrammingError, match="closed"):
+            connection.execute("SELECT 1")

--- a/tests/test_tls.py
+++ b/tests/test_tls.py
@@ -103,8 +103,10 @@ def test_tls_is_owned_and_serialized_by_the_transport() -> None:
     transport = HTTPTransport("https://127.0.0.1:8443", tls=server_tls)
     agent = Agent(_card("factory-agent", transport.url), transport=transport, verbosity=0)
     client_tls = _client_tls()
-    client = AgentClient("http", url="https://127.0.0.1:8444", tls=client_tls)
-    registry = Registry("http", url="https://127.0.0.1:8445", tls=client_tls, verbosity=0)
+    client_transport = HTTPTransport("https://127.0.0.1:8444", tls=client_tls)
+    client = AgentClient(client_transport)
+    registry_transport = HTTPTransport("https://127.0.0.1:8445", tls=_server_tls())
+    registry = Registry(registry_transport, verbosity=0)
 
     serialized = agent.to_dict()
     restored = Agent.from_dict(serialized)
@@ -112,8 +114,10 @@ def test_tls_is_owned_and_serialized_by_the_transport() -> None:
     assert "tls" not in serialized
     assert serialized["transport"]["tls"] == server_tls.to_dict()
     assert agent.transport is transport
+    assert client.transport is client_transport
     assert getattr(client.transport, "tls", None) is client_tls
-    assert getattr(registry.client.transport, "tls", None) is client_tls
+    assert registry.client.transport is registry_transport
+    assert getattr(registry.client.transport, "tls", None) == _server_tls()
     assert restored.transport is not None
     assert getattr(restored.transport, "tls", None) == server_tls
 

--- a/tests/test_tls.py
+++ b/tests/test_tls.py
@@ -97,17 +97,25 @@ def test_tls_config_serializes_paths_without_certificate_material() -> None:
     assert restored == config
 
 
-def test_top_level_tls_propagates_to_agent_client_and_registry() -> None:
-    """High-level constructors should forward TLS to factory-created transports."""
-    tls = _client_tls()
-    agent = Agent(_card("factory-agent", "https://127.0.0.1:8443"), transport="http", tls=tls, verbosity=0)
-    client = AgentClient("http", url="https://127.0.0.1:8444", tls=tls)
-    registry = Registry("http", url="https://127.0.0.1:8445", tls=tls, verbosity=0)
+def test_tls_is_owned_and_serialized_by_the_transport() -> None:
+    """Agent should preserve advanced TLS without promoting it to Agent state."""
+    server_tls = _server_tls()
+    transport = HTTPTransport("https://127.0.0.1:8443", tls=server_tls)
+    agent = Agent(_card("factory-agent", transport.url), transport=transport, verbosity=0)
+    client_tls = _client_tls()
+    client = AgentClient("http", url="https://127.0.0.1:8444", tls=client_tls)
+    registry = Registry("http", url="https://127.0.0.1:8445", tls=client_tls, verbosity=0)
 
-    assert agent.transport is not None and getattr(agent.transport, "tls", None) is tls
-    assert getattr(client._transport, "tls", None) is tls
-    assert getattr(registry.client.transport, "tls", None) is tls
-    assert Agent.from_dict(agent.to_dict()).tls == tls
+    serialized = agent.to_dict()
+    restored = Agent.from_dict(serialized)
+
+    assert "tls" not in serialized
+    assert serialized["transport"]["tls"] == server_tls.to_dict()
+    assert agent.transport is transport
+    assert getattr(client.transport, "tls", None) is client_tls
+    assert getattr(registry.client.transport, "tls", None) is client_tls
+    assert restored.transport is not None
+    assert getattr(restored.transport, "tls", None) == server_tls
 
 
 @pytest.mark.asyncio

--- a/tests/test_transport_conformance.py
+++ b/tests/test_transport_conformance.py
@@ -44,6 +44,7 @@ async def _assert_request_response_contract(agent: Agent, client: AgentClient) -
         assert card.name == agent.card.name
         assert task.get_last_part_content() == "transport ok"
     finally:
+        await client.transport.stop()
         await agent.server.stop()
 
 
@@ -57,6 +58,7 @@ async def _assert_streaming_contract(agent: Agent, client: AgentClient) -> None:
         assert events[-1]["final"] is True
         assert events[-1]["new_state"] == "completed"
     finally:
+        await client.transport.stop()
         await agent.server.stop()
 
 
@@ -92,11 +94,12 @@ async def test_http_transport_conforms_to_agent_request_response_contract(unused
     await _assert_request_response_contract(agent, client)
 
 
+@pytest.mark.parametrize("backend", ["starlette", "fastapi"])
 @pytest.mark.asyncio
-async def test_sse_transport_streams_until_final_task_status(unused_tcp_port) -> None:
+async def test_sse_transport_streams_until_final_task_status(unused_tcp_port, backend: str) -> None:
     """SSE should not stop when a nested LLM event marks itself final."""
     url = f"http://127.0.0.1:{unused_tcp_port}"
-    server_transport = SSEJSONRPCTransport(url=url, log_level="critical", access_log=False)
+    server_transport = SSEJSONRPCTransport(url=url, backend=backend, log_level="critical", access_log=False)
     client_transport = SSEJSONRPCTransport(
         url="http://127.0.0.1:0",
         log_level="critical",
@@ -118,6 +121,10 @@ async def test_sse_transport_streams_until_final_task_status(unused_tcp_port) ->
         assert events[-1]["type"] == "task_status_update"
         assert events[-1]["final"] is True
         assert events[-1]["new_state"] == "completed"
+        assert sum(event["type"] == "task_status_update" and event["final"] is True for event in events) == 1
+        assert server_transport.metrics.streams_started == 1
+        assert server_transport.metrics.streams_completed == 1
+        assert server_transport.metrics.active_streams == 0
     finally:
         await client_transport.stop()
         await agent.server.stop()

--- a/tests/test_transport_hardening.py
+++ b/tests/test_transport_hardening.py
@@ -1,0 +1,319 @@
+from __future__ import annotations
+
+import asyncio
+import threading
+from typing import Any
+
+import pytest
+
+from protolink import (
+    Agent,
+    AgentCard,
+    AgentInterface,
+    RetryPolicy,
+    TransportConfig,
+    TransportConnectionError,
+    TransportLimitError,
+    TransportLimits,
+)
+from protolink.client import AgentClient
+from protolink.client.request_spec import ClientRequestSpec
+from protolink.discovery import Registry
+from protolink.server.endpoint_handler import EndpointSpec
+from protolink.transport import RuntimeTransport, Transport, TransportRequestContext
+
+
+class HarnessTransport(Transport):
+    """Minimal transport used to exercise the shared production contract."""
+
+    def __init__(self, config: TransportConfig | None = None) -> None:
+        super().__init__(config=config)
+        self._url = "runtime://harness"
+
+    async def send(
+        self,
+        request_spec: ClientRequestSpec,
+        base_url: str,
+        data: Any = None,
+        params: dict[str, Any] | None = None,
+    ) -> Any:
+        del request_spec, base_url, data, params
+        return None
+
+    def setup_routes(self, endpoints: list[EndpointSpec]) -> None:
+        del endpoints
+
+    async def start(self) -> None:
+        self._transport_running = True
+
+    async def stop(self) -> None:
+        self._transport_running = False
+
+    def validate_url(self) -> bool:
+        return True
+
+    @property
+    def url(self) -> str:
+        return self._url
+
+
+def test_transport_config_validates_resource_bounds() -> None:
+    with pytest.raises(ValueError, match="max_request_bytes"):
+        TransportLimits(max_request_bytes=0)
+    with pytest.raises(ValueError, match="max_attempts"):
+        RetryPolicy(max_attempts=0)
+
+
+def test_transport_request_context_is_public() -> None:
+    context = TransportRequestContext(request_id="request-1", idempotency_key="operation-1")
+
+    assert context.next_attempt().attempt == 2
+
+
+def test_transport_rejects_oversized_payloads() -> None:
+    transport = HarnessTransport(
+        TransportConfig(limits=TransportLimits(max_request_bytes=4))
+    )
+
+    with pytest.raises(TransportLimitError, match="configured maximum"):
+        transport.check_payload_limit("too large", kind="request")
+
+
+@pytest.mark.asyncio
+async def test_retry_policy_only_retries_explicitly_idempotent_requests() -> None:
+    transport = HarnessTransport(
+        TransportConfig(
+            retry=RetryPolicy(
+                max_attempts=3,
+                initial_backoff=0,
+                max_backoff=0,
+                jitter=0,
+            )
+        )
+    )
+    spec = ClientRequestSpec(name="read", path="/value", method="GET", idempotent=True)
+    context = transport.new_request_context(spec)
+    attempts: list[str] = []
+
+    async def operation(attempt: Any) -> str:
+        attempts.append(attempt.request_id)
+        if len(attempts) == 1:
+            raise TransportConnectionError("temporary", retryable=True)
+        return "ok"
+
+    async with transport.request_slot():
+        assert await transport.run_with_retries(spec, context, operation) == "ok"
+
+    assert attempts == [context.request_id, context.request_id]
+    assert transport.metrics.retries == 1
+    assert transport.metrics.requests_succeeded == 1
+    assert transport.metrics.active_requests == 0
+
+
+@pytest.mark.asyncio
+async def test_runtime_transport_caches_idempotent_responses() -> None:
+    server = RuntimeTransport("runtime://server")
+    client = RuntimeTransport("runtime://client")
+    calls = 0
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def handler(payload: dict[str, Any]) -> dict[str, Any]:
+        nonlocal calls
+        calls += 1
+        started.set()
+        await release.wait()
+        return {"value": payload["value"]}
+
+    server.setup_routes(
+        [
+            EndpointSpec(
+                name="write",
+                path="/value",
+                method="POST",
+                handler=handler,
+                request_source="body",
+            )
+        ]
+    )
+    await server.start()
+    spec = ClientRequestSpec(name="write", path="/value", method="POST", idempotent=True)
+    payload = {"id": "same-operation", "value": 3}
+
+    try:
+        first = asyncio.create_task(client.send(spec, server.url, payload))
+        await started.wait()
+        duplicate = asyncio.create_task(client.send(spec, server.url, payload))
+        await asyncio.sleep(0)
+        release.set()
+        assert await first == {"value": 3}
+        assert await duplicate == {"value": 3}
+        assert await client.send(spec, server.url, payload) == {"value": 3}
+    finally:
+        await server.stop()
+        await client.stop()
+
+    assert calls == 1
+
+
+def test_agent_card_round_trips_additional_interfaces() -> None:
+    card = AgentCard(
+        name="worker",
+        description="Does work",
+        url="https://worker.example",
+        interfaces=[AgentInterface(url="grpcs://worker.example:443", transport="grpc")],
+    )
+
+    restored = AgentCard.from_dict(card.to_dict())
+
+    assert restored.url == card.url
+    assert restored.transport == "http"
+    assert restored.interfaces == card.interfaces
+
+
+def test_high_level_client_propagates_transport_config() -> None:
+    config = TransportConfig(retry=RetryPolicy(max_attempts=2))
+    client = AgentClient(
+        transport="runtime",
+        url="runtime://client",
+        transport_config=config,
+    )
+
+    assert client.transport.config is config
+
+
+def test_agent_and_registry_factories_propagate_transport_config() -> None:
+    config = TransportConfig(retry=RetryPolicy(max_attempts=2))
+    agent = Agent(
+        card=AgentCard(
+            name="configured-agent",
+            description="Exercises transport configuration propagation",
+            url="runtime://configured-agent",
+        ),
+        transport="runtime",
+        registry="runtime",
+        registry_url="runtime://configured-registry",
+        transport_config=config,
+    )
+    registry = Registry(
+        transport="runtime",
+        url="runtime://configured-registry",
+        transport_config=config,
+    )
+
+    assert agent.transport is not None
+    assert agent.transport.config is config
+    assert agent.registry_client is not None
+    assert agent.registry_client.transport.config is config
+    assert registry.client.transport.config is config
+
+
+@pytest.mark.asyncio
+async def test_health_and_lifecycle_are_idempotent() -> None:
+    transport = HarnessTransport()
+
+    await transport.start()
+    await transport.start()
+    assert transport.health()["ready"] is True
+    assert transport.health()["metrics"]["requests_started"] == 0
+
+    await transport.stop()
+    await transport.stop()
+    assert transport.health()["ready"] is False
+
+
+@pytest.mark.asyncio
+async def test_pooled_resources_close_on_their_owning_event_loop() -> None:
+    transport = HarnessTransport()
+    owner_loop = asyncio.new_event_loop()
+    owner_ready = threading.Event()
+    closed_on: list[int] = []
+
+    def run_owner_loop() -> None:
+        asyncio.set_event_loop(owner_loop)
+        owner_ready.set()
+        owner_loop.run_forever()
+        owner_loop.close()
+
+    owner_thread = threading.Thread(target=run_owner_loop)
+    owner_thread.start()
+    owner_ready.wait(timeout=2)
+
+    async def register_resource() -> None:
+        async def close_resource() -> None:
+            closed_on.append(threading.get_ident())
+
+        transport.register_loop_resource("background", close_resource)
+
+    try:
+        asyncio.run_coroutine_threadsafe(register_resource(), owner_loop).result(timeout=2)
+        await transport.close_loop_resources()
+        assert closed_on == [owner_thread.ident]
+    finally:
+        owner_loop.call_soon_threadsafe(owner_loop.stop)
+        owner_thread.join(timeout=2)
+
+
+@pytest.mark.asyncio
+async def test_http_health_probe_does_not_require_application_auth(unused_tcp_port: int) -> None:
+    httpx = pytest.importorskip("httpx")
+    from protolink.security import BearerTokenAuth
+    from protolink.transport import HTTPTransport
+
+    transport = HTTPTransport(
+        f"http://127.0.0.1:{unused_tcp_port}",
+        authenticator=BearerTokenAuth(secret="health-test-secret"),
+        log_level="critical",
+        access_log=False,
+    )
+    transport.setup_routes(
+        [
+            EndpointSpec(
+                name="health",
+                path="/healthz",
+                method="GET",
+                handler=transport.health,
+                request_source="none",
+            )
+        ]
+    )
+
+    await transport.start()
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.get(f"http://127.0.0.1:{unused_tcp_port}/healthz")
+        assert response.status_code == 200
+        assert response.json()["ready"] is True
+    finally:
+        await transport.stop()
+
+
+@pytest.mark.asyncio
+async def test_grpc_registers_standard_health_service(unused_tcp_port: int) -> None:
+    grpc = pytest.importorskip("grpc")
+    health_pb2 = pytest.importorskip("grpc_health.v1.health_pb2")
+    health_pb2_grpc = pytest.importorskip("grpc_health.v1.health_pb2_grpc")
+    reflection_pb2 = pytest.importorskip("grpc_reflection.v1alpha.reflection_pb2")
+    reflection_pb2_grpc = pytest.importorskip("grpc_reflection.v1alpha.reflection_pb2_grpc")
+    from protolink.transport import GRPCTransport
+
+    transport = GRPCTransport(f"grpc://127.0.0.1:{unused_tcp_port}")
+    await transport.start()
+    channel = grpc.aio.insecure_channel(f"127.0.0.1:{unused_tcp_port}")
+    try:
+        stub = health_pb2_grpc.HealthStub(channel)
+        response = await stub.Check(health_pb2.HealthCheckRequest(service=transport._SERVICE_NAME))
+        assert response.status == health_pb2.HealthCheckResponse.SERVING
+
+        async def reflection_requests():
+            yield reflection_pb2.ServerReflectionRequest(list_services="")
+
+        reflection_stub = reflection_pb2_grpc.ServerReflectionStub(channel)
+        responses = reflection_stub.ServerReflectionInfo(reflection_requests())
+        reflection_response = await anext(responses.__aiter__())
+        service_names = {service.name for service in reflection_response.list_services_response.service}
+        assert transport._SERVICE_NAME in service_names
+        assert "grpc.health.v1.Health" in service_names
+    finally:
+        await channel.close()
+        await transport.stop()

--- a/tests/test_transport_hardening.py
+++ b/tests/test_transport_hardening.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 import threading
 from typing import Any
 
@@ -16,7 +17,7 @@ from protolink import (
     TransportLimitError,
     TransportLimits,
 )
-from protolink.client import AgentClient
+from protolink.client import AgentClient, RegistryClient
 from protolink.client.request_spec import ClientRequestSpec
 from protolink.discovery import Registry
 from protolink.server.endpoint_handler import EndpointSpec
@@ -71,9 +72,7 @@ def test_transport_request_context_is_public() -> None:
 
 
 def test_transport_rejects_oversized_payloads() -> None:
-    transport = HarnessTransport(
-        TransportConfig(limits=TransportLimits(max_request_bytes=4))
-    )
+    transport = HarnessTransport(TransportConfig(limits=TransportLimits(max_request_bytes=4)))
 
     with pytest.raises(TransportLimitError, match="configured maximum"):
         transport.check_payload_limit("too large", kind="request")
@@ -182,30 +181,60 @@ def test_high_level_client_propagates_transport_config() -> None:
     assert client.transport.config is config
 
 
-def test_agent_and_registry_factories_propagate_transport_config() -> None:
-    config = TransportConfig(retry=RetryPolicy(max_attempts=2))
+def test_agent_and_registry_transports_own_independent_config() -> None:
+    agent_config = TransportConfig(retry=RetryPolicy(max_attempts=2))
+    registry_config = TransportConfig(
+        limits=TransportLimits(max_concurrent_requests=25),
+    )
+    agent_transport = RuntimeTransport("runtime://configured-agent", config=agent_config)
+    registry_transport = RuntimeTransport("runtime://configured-registry", config=registry_config)
     agent = Agent(
         card=AgentCard(
             name="configured-agent",
             description="Exercises transport configuration propagation",
             url="runtime://configured-agent",
         ),
-        transport="runtime",
-        registry="runtime",
-        registry_url="runtime://configured-registry",
-        transport_config=config,
+        transport=agent_transport,
+        registry=RegistryClient(registry_transport),
     )
     registry = Registry(
         transport="runtime",
         url="runtime://configured-registry",
-        transport_config=config,
+        transport_config=registry_config,
+    )
+    restored = Agent.from_dict(agent.to_dict())
+
+    assert agent.transport is agent_transport
+    assert agent.transport.config is agent_config
+    assert agent.registry_client is not None
+    assert agent.registry_client.transport is registry_transport
+    assert agent.registry_client.transport.config is registry_config
+    assert registry.client.transport.config is registry_config
+    assert restored.transport is not None
+    assert restored.transport.config == agent_config
+    assert restored.registry_client is not None
+    assert restored.registry_client.transport.config == registry_config
+
+
+def test_agent_string_transport_uses_simple_defaults() -> None:
+    agent = Agent(
+        card=AgentCard(
+            name="simple-agent",
+            description="Exercises the zero-configuration path",
+            url="runtime://simple-agent",
+        ),
+        transport="runtime",
     )
 
     assert agent.transport is not None
-    assert agent.transport.config is config
-    assert agent.registry_client is not None
-    assert agent.registry_client.transport.config is config
-    assert registry.client.transport.config is config
+    assert agent.transport.config == TransportConfig()
+
+
+def test_agent_constructor_keeps_advanced_settings_on_transport() -> None:
+    parameters = inspect.signature(Agent).parameters
+
+    assert "tls" not in parameters
+    assert "transport_config" not in parameters
 
 
 @pytest.mark.asyncio

--- a/tests/test_transport_hardening.py
+++ b/tests/test_transport_hardening.py
@@ -170,14 +170,12 @@ def test_agent_card_round_trips_additional_interfaces() -> None:
     assert restored.interfaces == card.interfaces
 
 
-def test_high_level_client_propagates_transport_config() -> None:
+def test_client_uses_configured_transport_instance() -> None:
     config = TransportConfig(retry=RetryPolicy(max_attempts=2))
-    client = AgentClient(
-        transport="runtime",
-        url="runtime://client",
-        transport_config=config,
-    )
+    transport = RuntimeTransport("runtime://client", config=config)
+    client = AgentClient(transport)
 
+    assert client.transport is transport
     assert client.transport.config is config
 
 
@@ -197,11 +195,11 @@ def test_agent_and_registry_transports_own_independent_config() -> None:
         transport=agent_transport,
         registry=RegistryClient(registry_transport),
     )
-    registry = Registry(
-        transport="runtime",
-        url="runtime://configured-registry",
-        transport_config=registry_config,
+    standalone_registry_transport = RuntimeTransport(
+        "runtime://standalone-configured-registry",
+        config=registry_config,
     )
+    registry = Registry(transport=standalone_registry_transport)
     restored = Agent.from_dict(agent.to_dict())
 
     assert agent.transport is agent_transport
@@ -209,6 +207,7 @@ def test_agent_and_registry_transports_own_independent_config() -> None:
     assert agent.registry_client is not None
     assert agent.registry_client.transport is registry_transport
     assert agent.registry_client.transport.config is registry_config
+    assert registry.client.transport is standalone_registry_transport
     assert registry.client.transport.config is registry_config
     assert restored.transport is not None
     assert restored.transport.config == agent_config
@@ -235,6 +234,16 @@ def test_agent_constructor_keeps_advanced_settings_on_transport() -> None:
 
     assert "tls" not in parameters
     assert "transport_config" not in parameters
+
+
+def test_client_and_registry_constructors_keep_advanced_settings_on_transport() -> None:
+    client_parameters = inspect.signature(AgentClient).parameters
+    registry_parameters = inspect.signature(Registry).parameters
+
+    assert "tls" not in client_parameters
+    assert "transport_config" not in client_parameters
+    assert "tls" not in registry_parameters
+    assert "transport_config" not in registry_parameters
 
 
 @pytest.mark.asyncio

--- a/tests/test_transport_hardening.py
+++ b/tests/test_transport_hardening.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import json
 import threading
+from types import SimpleNamespace
 from typing import Any
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -16,6 +19,7 @@ from protolink import (
     TransportConnectionError,
     TransportLimitError,
     TransportLimits,
+    TransportTimeoutError,
 )
 from protolink.client import AgentClient, RegistryClient
 from protolink.client.request_spec import ClientRequestSpec
@@ -155,6 +159,224 @@ async def test_runtime_transport_caches_idempotent_responses() -> None:
     assert calls == 1
 
 
+@pytest.mark.asyncio
+async def test_websocket_does_not_cache_failed_idempotent_responses() -> None:
+    pytest.importorskip("websockets")
+    from protolink.transport import WebSocketTransport
+
+    calls = 0
+
+    async def handler(payload: dict[str, Any]) -> dict[str, Any]:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise RuntimeError("temporary failure")
+        return {"value": payload["value"]}
+
+    transport = WebSocketTransport("ws://127.0.0.1:9000")
+    transport.setup_routes(
+        [EndpointSpec(name="write", path="/value", method="POST", handler=handler, request_source="body")]
+    )
+    frames = iter(
+        [
+            json.dumps(
+                {
+                    "id": "request-1",
+                    "idempotency_key": "same-operation",
+                    "method": "POST",
+                    "path": "/value",
+                    "data": {"value": 3},
+                }
+            ),
+            json.dumps(
+                {
+                    "id": "request-2",
+                    "idempotency_key": "same-operation",
+                    "method": "POST",
+                    "path": "/value",
+                    "data": {"value": 3},
+                }
+            ),
+        ]
+    )
+
+    class FakeWebSocket:
+        def __init__(self) -> None:
+            self.responses: list[str] = []
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self) -> str:
+            try:
+                return next(frames)
+            except StopIteration:
+                raise StopAsyncIteration from None
+
+        async def send(self, response: str) -> None:
+            self.responses.append(response)
+
+    websocket = FakeWebSocket()
+    await transport._handle_connection(websocket)
+    responses = [json.loads(response) for response in websocket.responses]
+
+    assert responses[0]["ok"] is False
+    assert responses[1] == {"id": "request-2", "ok": True, "result": {"value": 3}}
+    assert calls == 2
+
+
+@pytest.mark.asyncio
+async def test_grpc_does_not_cache_failed_idempotent_responses() -> None:
+    pytest.importorskip("grpc")
+    from protolink.transport import GRPCTransport
+
+    calls = 0
+
+    async def handler(payload: dict[str, Any]) -> dict[str, Any]:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise RuntimeError("temporary failure")
+        return {"value": payload["value"]}
+
+    transport = GRPCTransport("grpc://127.0.0.1:9000")
+    transport.setup_routes(
+        [EndpointSpec(name="write", path="/value", method="POST", handler=handler, request_source="body")]
+    )
+    context = SimpleNamespace(invocation_metadata=lambda: ())
+    first = await transport._handle_unary(
+        {
+            "id": "request-1",
+            "idempotency_key": "same-operation",
+            "method": "POST",
+            "path": "/value",
+            "data": {"value": 3},
+        },
+        context,
+    )
+    second = await transport._handle_unary(
+        {
+            "id": "request-2",
+            "idempotency_key": "same-operation",
+            "method": "POST",
+            "path": "/value",
+            "data": {"value": 3},
+        },
+        context,
+    )
+
+    assert first["ok"] is False
+    assert second == {"id": "request-2", "ok": True, "result": {"value": 3}}
+    assert calls == 2
+
+
+@pytest.mark.asyncio
+async def test_websocket_timeout_discards_the_pooled_connection(monkeypatch: pytest.MonkeyPatch) -> None:
+    pytest.importorskip("websockets")
+    from protolink.transport import WebSocketTransport
+
+    transport = WebSocketTransport("ws://127.0.0.1:9000", timeout=0.01)
+    connection = SimpleNamespace(
+        send=AsyncMock(),
+        recv=AsyncMock(side_effect=TimeoutError),
+        close=AsyncMock(),
+    )
+
+    async def ensure_connection(base_url: str, loop_key: str, *, request_id: str | None = None) -> Any:
+        del base_url, request_id
+        transport._client_conns[loop_key] = connection
+        return connection
+
+    monkeypatch.setattr(transport, "_ensure_client_connection", ensure_connection)
+    spec = ClientRequestSpec(name="read", path="/value", method="GET")
+
+    with pytest.raises(TransportTimeoutError):
+        await transport.send(spec, "ws://127.0.0.1:9001")
+
+    assert transport._client_conns == {}
+    connection.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_websocket_request_discards_the_pooled_connection(monkeypatch: pytest.MonkeyPatch) -> None:
+    pytest.importorskip("websockets")
+    from protolink.transport import WebSocketTransport
+
+    transport = WebSocketTransport("ws://127.0.0.1:9000")
+    sent = asyncio.Event()
+    never_respond = asyncio.Event()
+
+    async def send(raw: str) -> None:
+        del raw
+        sent.set()
+
+    async def recv() -> str:
+        await never_respond.wait()
+        raise AssertionError("unreachable")
+
+    connection = SimpleNamespace(send=send, recv=recv, close=AsyncMock())
+
+    async def ensure_connection(base_url: str, loop_key: str, *, request_id: str | None = None) -> Any:
+        del base_url, request_id
+        transport._client_conns[loop_key] = connection
+        return connection
+
+    monkeypatch.setattr(transport, "_ensure_client_connection", ensure_connection)
+    spec = ClientRequestSpec(name="read", path="/value", method="GET")
+    request = asyncio.create_task(transport.send(spec, "ws://127.0.0.1:9001"))
+    await sent.wait()
+    request.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await request
+
+    assert transport._client_conns == {}
+    connection.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_abandoned_websocket_stream_discards_the_pooled_connection(monkeypatch: pytest.MonkeyPatch) -> None:
+    pytest.importorskip("websockets")
+    from protolink.transport import WebSocketTransport
+
+    transport = WebSocketTransport("ws://127.0.0.1:9000")
+
+    class FakeConnection:
+        def __init__(self) -> None:
+            self.request: dict[str, Any] | None = None
+            self.close = AsyncMock()
+
+        async def send(self, raw: str) -> None:
+            self.request = json.loads(raw)
+
+        async def recv(self) -> str:
+            assert self.request is not None
+            return json.dumps(
+                {
+                    "id": self.request["id"],
+                    "ok": True,
+                    "result": {"type": "task_progress", "final": False},
+                    "final": False,
+                }
+            )
+
+    connection = FakeConnection()
+
+    async def ensure_connection(base_url: str, loop_key: str, *, request_id: str | None = None) -> Any:
+        del base_url, request_id
+        transport._client_conns[loop_key] = connection
+        return connection
+
+    monkeypatch.setattr(transport, "_ensure_client_connection", ensure_connection)
+    stream = transport.subscribe("ws://127.0.0.1:9001", {"id": "task-1"})
+
+    assert await anext(stream) == {"type": "task_progress", "final": False}
+    await stream.aclose()
+
+    assert transport._client_conns == {}
+    connection.close.assert_awaited_once()
+
+
 def test_agent_card_round_trips_additional_interfaces() -> None:
     card = AgentCard(
         name="worker",
@@ -168,6 +390,33 @@ def test_agent_card_round_trips_additional_interfaces() -> None:
     assert restored.url == card.url
     assert restored.transport == "http"
     assert restored.interfaces == card.interfaces
+
+
+def test_agent_round_trip_restores_registry_authentication() -> None:
+    from protolink.security import APIKeyAuth
+    from protolink.transport import HTTPTransport
+
+    authenticator = APIKeyAuth(valid_keys={"secret": "client"})
+    registry_transport = HTTPTransport(
+        "https://registry.example",
+        authenticator=authenticator,
+        credentials="secret",
+    )
+    agent = Agent(
+        AgentCard(name="worker", description="Does work", url="https://worker.example"),
+        transport=HTTPTransport("https://worker.example"),
+        registry=RegistryClient(registry_transport),
+        authenticator=authenticator,
+        credentials="secret",
+        verbosity=0,
+    )
+
+    restored = Agent.from_dict(agent.to_dict())
+
+    assert restored.registry_client is not None
+    restored_transport = restored.registry_client.transport
+    assert isinstance(restored_transport.authenticator, APIKeyAuth)
+    assert restored_transport.credentials == "secret"
 
 
 def test_client_uses_configured_transport_instance() -> None:
@@ -292,8 +541,9 @@ async def test_pooled_resources_close_on_their_owning_event_loop() -> None:
         owner_thread.join(timeout=2)
 
 
+@pytest.mark.parametrize("backend", ["starlette", "fastapi"])
 @pytest.mark.asyncio
-async def test_http_health_probe_does_not_require_application_auth(unused_tcp_port: int) -> None:
+async def test_http_health_probe_does_not_require_application_auth(unused_tcp_port: int, backend: str) -> None:
     httpx = pytest.importorskip("httpx")
     from protolink.security import BearerTokenAuth
     from protolink.transport import HTTPTransport
@@ -301,6 +551,7 @@ async def test_http_health_probe_does_not_require_application_auth(unused_tcp_po
     transport = HTTPTransport(
         f"http://127.0.0.1:{unused_tcp_port}",
         authenticator=BearerTokenAuth(secret="health-test-secret"),
+        backend=backend,
         log_level="critical",
         access_log=False,
     )
@@ -322,6 +573,9 @@ async def test_http_health_probe_does_not_require_application_auth(unused_tcp_po
             response = await client.get(f"http://127.0.0.1:{unused_tcp_port}/healthz")
         assert response.status_code == 200
         assert response.json()["ready"] is True
+        assert transport.metrics.requests_started == 1
+        assert transport.metrics.requests_succeeded == 1
+        assert transport.metrics.active_requests == 0
     finally:
         await transport.stop()
 


### PR DESCRIPTION
- **Shared production transport contract**
  - Added `TransportConfig`, `TransportLimits`, and `RetryPolicy` for consistent payload bounds, request/stream concurrency, explicit idempotent retries, keepalive, graceful shutdown, response deduplication, and dependency-free metrics across every built-in transport.
  - Added `TransportCapabilities`, `TransportMetricsSnapshot`, and the public `TransportRequestContext` extension type for capability inspection, operational counters, correlation IDs, idempotency keys, and retry-attempt tracking.
  - Added typed connection, timeout, protocol, remote, and payload-limit errors carrying URL, request ID, retryability, and protocol-native status metadata.
  - Added `/healthz` and `/readyz` Agent and Registry probes, configurable WebSocket ping/pong behavior, loop-owned pooled-resource cleanup, and idempotent transport lifecycle methods.
- **Multi-transport Agent metadata**
  - Added optional `AgentCard.interfaces` / `AgentInterface` metadata so one Agent can advertise additional protocol endpoints while retaining its primary URL and transport.
  - Serialized this metadata as `additionalInterfaces` for wire compatibility and preserved it through AgentCard round trips.
- Added `examples/transport_production.py` with provider-free configuration, capability, health, and metric inspection.

### Changed

- `Agent`, `AgentClient`, and `Registry` now accept `transport_config=` when constructing transports by name; directly supplied transport objects retain ownership of their existing configuration.
- `ClientRequestSpec` now declares operation idempotency explicitly. Retries remain disabled by default and run only when the request specification, method, and typed failure all permit a safe retry.
- HTTP, SSE JSON-RPC, WebSocket, gRPC, and RuntimeTransport now enforce the same serialized payload and concurrency contract, so in-process tests exercise the same resource boundaries as network deployments.
- Correlation IDs remain stable across retry attempts, while idempotency keys suppress concurrent duplicate execution and replay completed responses within the configured process-local cache window.
- Expanded the Transport, Agent, Client, Registry, and AgentCard documentation with complete signatures, defaults, protocol mappings, operational rationale, custom-transport guidance, and production examples. The documentation landing-page IDE now includes gRPC and production transport configuration with incremental line editing.

### Fixed

- Fixed concurrent duplicate idempotent requests so they await one in-flight operation instead of executing the same handler more than once.
- Fixed HTTP health probes so `/healthz` and `/readyz` remain available when application authentication is enabled.
- Fixed transport shutdown across background-thread and caller event loops by closing pooled clients and channels on the event loop that owns them.
