### PR TITLE
add diff_run cli tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Install the integrations used here with `uv add "protolink[http,mcp]"`; the Olla
 | [Telemetry](https://nmaroulis.github.io/protolink/docs/telemetry/) | Dependency-free local traces, Langfuse, LangSmith, multi-telemetry, custom |
 | [Authentication](https://nmaroulis.github.io/protolink/docs/authentication/) | API keys, bearer JWT, basic auth, OAuth delegation, TLS |
 | [Logging](https://nmaroulis.github.io/protolink/docs/logging/) | Colored console, text/JSON files, quiet logger, custom `BaseLogger` |
-| [Runtime control](https://nmaroulis.github.io/protolink/docs/runtime/) | Budgets, cancellation, policy, approvals, events, reports, replay, redaction |
+| [Runtime control](https://nmaroulis.github.io/protolink/docs/runtime/) | Budgets, cancellation, policy, approvals, events, reports, replay, regression diffing, redaction |
 
 ## LLM-agnostic, with a strong local focus
 
@@ -284,7 +284,7 @@ result = agent.sync.invoke("Trace this task")
 trace = telemetry.recorder.replay()[-1]
 ```
 
-The same runtime contracts power cancellation, budgets, policy decisions, approval previews, run reports, redaction, and deterministic replay.
+The same runtime contracts power cancellation, budgets, policy decisions, approval previews, run reports, redaction, read-only replay, and normalized report comparison for regression testing. Replay and comparison never re-execute model or tool calls: execute the candidate separately against controlled dependencies, record its report, and then diff it against the baseline. Normalization is limited to known ProtoLink report-envelope fields; application-owned payloads and report metadata remain exact unless you configure an ignore rule or numeric tolerance.
 
 ## Dashboard developer tool
 
@@ -298,12 +298,13 @@ It reads task snapshots and `RunReport` records from `SQLiteRunStore`, loads `Ag
 
 ![ProtoLink dashboard overview](https://raw.githubusercontent.com/nMaroulis/protolink/main/docs/assets/devtools-dashboard.gif)
 
-The CLI also includes project scaffolding, environment diagnostics, registry inspection, and run replay:
+The CLI also includes project scaffolding, environment diagnostics, registry inspection, run replay, and normalized report diffing:
 
 ```bash
 protolink init agent
 protolink doctor
 protolink run list --store runs.db
+protolink run diff baseline_run candidate_run --store runs.db
 ```
 
 See the [developer tools guide](https://nmaroulis.github.io/protolink/docs/devtools/).
@@ -312,6 +313,7 @@ See the [developer tools guide](https://nmaroulis.github.io/protolink/docs/devto
 
 - [Built-in multi-engine web search](https://github.com/nMaroulis/protolink/blob/main/examples/builtin_web_search.py)
 - [Provider-free runtime mesh](https://github.com/nMaroulis/protolink/blob/main/examples/provider_free_mesh.py)
+- [Normalized run regression diffing](https://github.com/nMaroulis/protolink/blob/main/examples/run_regression_diff.py)
 - [HTTP agent communication](https://github.com/nMaroulis/protolink/blob/main/examples/http_agents.py)
 - [Production transport configuration](https://github.com/nMaroulis/protolink/blob/main/examples/transport_production.py)
 - [Runtime policy and approvals](https://github.com/nMaroulis/protolink/blob/main/examples/runtime_policy_and_approvals.py)

--- a/docs/content/changelog.md
+++ b/docs/content/changelog.md
@@ -34,14 +34,14 @@ uv add --upgrade protolink
 
 # Release Notes
 
-## [0.6.6] - 2026-07-16
+## [0.6.6] - 2026-07-17
 
 :::note Latest release
 
-This release adds a small opt-in built-in tool set and makes ProtoLink's A2A architecture explicit without replacing
-its small Python runtime API.
+This release adds normalized run-report regression diffing, a small opt-in built-in tool set, and an explicit
+description of ProtoLink's A2A architecture without replacing its small Python runtime API.
 `AgentCard`, `Task`, `Message`, `Part`, and `Artifact` remain ProtoLink's ergonomic runtime primitives.
-An HTTP agent can now opt into a separate, versioned A2A 1.0 inbound and outbound translation boundary with 
+An HTTP agent can now opt into a separate, versioned A2A 1.0 inbound and outbound translation boundary with
 `Agent(..., a2a=True)`. The default `False` preserves existing ProtoLink clients, native endpoints, transports
 and `handle_task(Task)` implementations.
 
@@ -49,6 +49,12 @@ and `handle_task(Task)` implementations.
 
 ### Added
 
+- **Normalized run-report regression diffing**
+  - Added `RunReportDiff`, `RunReportDifference`, `RunReportDiffConfig`, `RunReportTolerance`, `ALL_RUN_REPORT_SECTIONS`, `normalize_run_report()`, `diff_run_reports()`, and `assert_run_matches()` for comparing baseline and candidate reports. Regression suites normally record final reports, but the helpers do not require a particular task lifecycle state.
+  - Comparisons normalize known ProtoLink runtime-envelope identifiers, timestamps, and sequence counters while preserving repeated identifier relationships, report structured path-level changes, and support configurable ignored paths and numeric tolerances without mutating the source reports. Application-owned payloads and report metadata remain exact by default.
+  - Added `protolink run diff BASELINE CANDIDATE --store runs.db [--json]` for offline comparison of two stored reports. The command exits `0` for a match, `1` for behavioral changes, and `2` when either report is missing.
+  - Text and JSON CLI diff output apply the default redaction policy to compared values. The core `RunReportDiff.to_dict()` API remains raw unless the caller supplies a redaction policy.
+  - Added the provider-free `examples/run_regression_diff.py` walkthrough for pinning a baseline, detecting a changed result, and using the assertion helper in tests.
 - **Opt-in dependency-free built-in tools**
   - Added `web_search()`, `fetch_url()`, `calculator()`, and `current_datetime()` factories, exported from `protolink.tools` and registered explicitly with `agent.add_tool(factory())`.
   - `web_search` selects `engine="brave"` by default, documented keyless English Wikipedia search with `engine="wikipedia"`, or keyless best-effort DuckDuckGo HTML search with `engine="duckduckgo"`. All three use the same bounded normalized result contract with no silent provider fallback. Brave reads `BRAVE_SEARCH_API_KEY` only at invocation; DuckDuckGo challenge and markup-drift responses fail explicitly, while recognized sponsored entries are retained and labeled.

--- a/docs/content/cli.md
+++ b/docs/content/cli.md
@@ -1,13 +1,13 @@
 # CLI
 
-Protolink ships with a command-line interface for project scaffolding, local health checks, registry inspection, run replay, and the local dashboard developer tools.
+Protolink ships with a command-line interface for project scaffolding, local health checks, registry inspection, run replay and regression diffing, and the local dashboard developer tools.
 
 The CLI is meant to be the shortest path from "I have a Protolink project" to "I can see what is installed, what agents are registered, what happened during a run, and how my agent topology is shaped." It does not replace the Python API. Instead, it sits on top of the same public runtime contracts that applications use directly: `AgentCard`, `RunContext`, `RunEvent`, `RunReport`, `SQLiteRunStore`, and registry discovery.
 
 Use the CLI in three common moments:
 
 - **First setup**: create a starter agent and confirm optional dependencies with `protolink doctor`.
-- **Local debugging**: inspect registry entries, list stored runs, and replay a run timeline without writing custom scripts.
+- **Local debugging and regression checks**: inspect registry entries, list stored runs, replay a timeline, and compare stored reports without writing custom scripts.
 - **Developer presentation**: open the dashboard when you want a visual view of runs, agents, and the future Studio preview.
 
 Most inspection commands support both human-readable terminal output and JSON. Use text while working interactively; use `--json` when integrating with CI, shell scripts, notebooks, or another application.
@@ -185,6 +185,26 @@ The difference matters:
 
 Use `run list` first when you do not remember the run ID. Use `run replay` when you want to understand why a run behaved a certain way. Use `--json` if you want to feed the replay into another renderer or a golden-run assertion workflow.
 
+Compare two run reports from the same store:
+
+```bash
+protolink run diff baseline_run candidate_run --store runs.db
+```
+
+`run diff` loads reports only; unlike `run replay`, it does not fall back to task snapshots. It canonicalizes known ProtoLink runtime-envelope identifiers, timestamps, sequence counters, and runtime-derived timing fields, then compares the remaining report content. Application-owned tool payloads and report metadata remain exact. This lets CI detect changes in event sequences, actions, approvals, artifacts, metrics, and final task output.
+
+The command compares facts that have already been recorded; it does not run either agent. Execute the candidate separately with the same input and controlled or captured model, tool, and external-service dependencies before comparing it with the baseline. A comparison against live dependencies can show what changed, but it cannot make those dependencies deterministic. Final reports are the usual regression input, although the API and CLI do not enforce a task lifecycle state.
+
+The exit status is designed for automation:
+
+| Exit | Meaning |
+| --- | --- |
+| `0` | The normalized reports match. |
+| `1` | The reports contain behavioral differences. |
+| `2` | One or both report IDs are missing from the store. |
+
+Use `--json` for a structured result containing the baseline and candidate selectors, `status` (`match`, `changed`, or `missing`), missing IDs, changed sections, and path-level differences. The default text view prints `Normalized run report diff: BASELINE -> CANDIDATE`, followed by `Result: MATCH` or `Result: CHANGED`. Both text and JSON output apply ProtoLink's default redaction policy to baseline and candidate values in a difference; the JSON Pointer path remains visible.
+
 ## Dashboard
 
 Open the local dashboard:
@@ -231,6 +251,7 @@ protolink registry list --url URL [--name NAME] [--role ROLE] [--tag TAG] [--jso
 protolink registry inspect SELECTOR --url URL [--json]
 protolink run list [--store PATH] [--limit N] [--json]
 protolink run replay RUN_ID [--store PATH] [--json]
+protolink run diff BASELINE CANDIDATE [--store PATH] [--json]
 protolink dashboard [--store PATH] [--registry-url URL] [--host HOST] [--port PORT] [--open] [--output PATH]
 ```
 

--- a/docs/content/devtools.md
+++ b/docs/content/devtools.md
@@ -10,7 +10,7 @@ The current surface has four command groups plus one disabled dashboard preview:
 
 - `protolink doctor` checks local installation, optional extras, run-store readability, and optional agent/registry endpoints.
 - `protolink registry list` and `protolink registry inspect` inspect a running HTTP registry.
-- `protolink run list` and `protolink run replay` read durable task snapshots and run reports.
+- `protolink run list`, `protolink run replay`, and `protolink run diff` inspect durable task snapshots and run reports.
 - `protolink dashboard` serves or writes a local HTML dashboard for runs and registry state, with a disabled Studio preview tab.
 
 ## When To Use Each Tool
@@ -22,6 +22,7 @@ The current surface has four command groups plus one disabled dashboard preview:
 | `registry inspect` | You want one full agent card by name or URL. | Registry `/agents/` endpoint. | No |
 | `run list` | You need recent task snapshots and run-report IDs. | `SQLiteRunStore`. | No |
 | `run replay` | You need a readable timeline for a stored run. | `SQLiteRunStore`. | No |
+| `run diff` | You need a normalized regression comparison between two stored reports. | `SQLiteRunStore`. | No |
 | `dashboard` | You want a local visual summary of registry and run-store state. | Registry and/or `SQLiteRunStore`. | No |
 | Dashboard Studio preview | You want to see where the future topology canvas will live. | Starter blueprint preview. | No |
 
@@ -187,6 +188,20 @@ A good replay should answer questions such as:
 
 Replay is not deterministic re-execution. It is a read-only reconstruction of recorded facts. That distinction is important for debugging: you can inspect a run without causing side effects, making provider calls, or repeating tool actions.
 
+## Run Regression Diffing
+
+After executing and recording a candidate separately against the same controlled inputs and dependencies as a baseline, compare the two stored reports offline:
+
+```bash
+protolink run diff baseline_run candidate_run --store runs.db
+```
+
+The comparison canonicalizes known ProtoLink runtime-envelope identifiers, timestamps, sequence counters, and runtime-derived timing fields before reporting path-level differences. Application-owned tool payloads and report metadata remain exact. It does not execute an agent, contact a provider, or repeat a tool action. With live models or external services, the result shows what changed; it does not make those dependencies deterministic. Regression suites normally compare final reports, but report lookup does not enforce a task lifecycle state.
+
+`run diff` requires two `RunReport` records in the same `SQLiteRunStore`. It deliberately does not compare task-snapshot fallbacks because a snapshot does not contain the full event, action, approval, artifact, and metric record.
+
+The command exits `0` when the normalized reports match, `1` when they changed, and `2` when either report is missing. Add `--json` in CI or custom tooling to receive `status`, `missing_run_ids`, `changed_sections`, and structured differences in addition to the baseline and candidate selectors. Both terminal and JSON output mask sensitive baseline/candidate values with the default redaction policy while retaining their JSON Pointer paths.
+
 ## Dashboard
 
 Serve the local dashboard:
@@ -257,26 +272,27 @@ Typical uses:
 - Explain how an agent plugs into LLMs, tools, telemetry, registry, and storage.
 - Keep the future structured-flow or scaffold-generator direction visible.
 
-## Renderer APIs
+## Collector And Renderer APIs
 
 The UI pieces live in `protolink.utils.renderers.devtools`:
 
 <ApiSurface
   eyebrow="Developer tooling module"
-  title="Devtools Renderers"
+  title="Devtools Collectors And Renderers"
   path="protolink.devtools"
-  description="The collector and renderer API for local dashboards, run replay, registry inspection, chat probes, terminal summaries, and application-specific debug panels."
+  description="The collector and renderer API for local dashboards, run replay and comparison, registry inspection, chat probes, terminal summaries, and application-specific debug panels."
   pills={[
     "Dashboard snapshots",
     "HTML renderer",
     "Text renderer",
     "Run replay",
+    "Run diff",
     "Agent probes",
   ]}
   cards={[
     {
       title: "Collect",
-      text: "Build plain dashboard and run-replay data structures from local run stores and registry state.",
+      text: "Build plain dashboard, replay, and report-diff data structures from local run stores and registry state.",
       code: "build_dashboard_snapshot()",
     },
     {
@@ -286,7 +302,7 @@ The UI pieces live in `protolink.utils.renderers.devtools`:
     },
     {
       title: "Render text",
-      text: "Format terminal-friendly run lists, replay output, and inspection summaries.",
+      text: "Format terminal-friendly run lists, replay output, normalized report diffs, and inspection summaries.",
       code: "DevtoolsTextRenderer",
     },
     {
@@ -314,7 +330,7 @@ Use `DevtoolsTextRenderer` for terminals and logs. Use `DevtoolsHtmlRenderer` fo
 
 The collectors and renderers are separate on purpose:
 
-- Collectors such as `build_dashboard_snapshot()`, `list_run_store_records()`, and `build_run_replay_view()` return plain dictionaries or small dataclasses.
+- Collectors such as `build_dashboard_snapshot()`, `list_run_store_records()`, `build_run_replay_view()`, and `build_run_diff_view()` return plain dictionaries or small dataclasses.
 - Agent actions such as `ping_agent()` and `chat_with_agent()` call public HTTP agent endpoints. They are deliberately separate from the renderer so applications can reuse them in their own debug panels.
 - Text renderers turn those structures into terminal-friendly tables.
 - HTML renderers turn those structures into standalone dashboard pages with registry health, chat, run replay, and the disabled Studio preview included.
@@ -330,6 +346,18 @@ view = build_run_replay_view("runs.db", "dashboard_demo_1")
 for item in view.items:
     print(item.event_type, item.summary)
 ```
+
+The stored-report comparison collector returns a `RunDiffView`:
+
+```python
+from protolink.devtools import build_run_diff_view
+
+view = build_run_diff_view("runs.db", "baseline_run", "candidate_run")
+print(view.status)  # "match", "changed", or "missing"
+safe_payload = view.to_dict()  # diff values are redacted by default
+```
+
+`build_run_diff_view()` requires two report records and never falls back to task snapshots. `RunDiffView.diff` is the core `RunReportDiff` when both reports exist; otherwise `missing_run_ids` identifies the failed lookups. Passing `redaction_policy=None` to `RunDiffView.to_dict()` returns raw values, so keep the default or supply a policy when the payload can leave the process.
 
 ## Provider-Free Example
 

--- a/docs/content/examples.md
+++ b/docs/content/examples.md
@@ -100,6 +100,10 @@ Run it without a query to inspect the CLI without making a network request.
 - [`provider_free_mesh.py`](https://github.com/nMaroulis/protolink/blob/main/examples/provider_free_mesh.py) runs a deterministic three-agent mesh with no provider, API key, registry, or network port. It demonstrates the A2A-derived `AgentCard`, `Task`, and `Message` model through the in-process runtime transport.
 - [`a2a_tck_agent.py`](https://github.com/nMaroulis/protolink/blob/main/examples/a2a_tck_agent.py) is the provider-free HTTP fixture for the official A2A 1.0 TCK. It explicitly uses `Agent(..., a2a=True)`; ordinary HTTP agents remain native-only by default. It is a compatibility test target, not a substitute for a published passing TCK result; follow the pinned instructions in [A2A Core and 1.0 Compatibility](a2a.md).
 
+### Run regression diffing
+
+- [`run_regression_diff.py`](https://github.com/nMaroulis/protolink/blob/main/examples/run_regression_diff.py) creates provider-free baseline and candidate reports with different known runtime IDs, timestamps, sequence counters, and bounded latency, proves that schema-aware normalization plus an explicit tolerance remove that noise, and then detects a real final-output change with `diff_run_reports()` and `assert_run_matches()`. Real candidate runs must be executed and recorded separately.
+
 ### 🧩 Protolink 0.6.3 runtime-control examples
 
 The 0.6.3 examples are small, provider-free scripts intended for application integrators:

--- a/docs/content/runtime.md
+++ b/docs/content/runtime.md
@@ -10,7 +10,7 @@ The runtime layer does not replace transports, telemetry, storage, or structured
   eyebrow="Runtime control layer"
   title="Runtime Primitives"
   path="protolink.runtime"
-  description="The application-facing contracts for run context, cancellation, budgets, policies, approvals, actions, normalized events, reports, replay, and redaction."
+  description="The application-facing contracts for run context, cancellation, budgets, policies, approvals, actions, normalized events, reports, replay, regression comparison, and redaction."
   pills={[
     "RunContext",
     "RunBudget",
@@ -18,6 +18,7 @@ The runtime layer does not replace transports, telemetry, storage, or structured
     "ApprovalRequest",
     "RunEvent",
     "RunReport",
+    "RunReportDiffConfig",
   ]}
   cards={[
     {
@@ -36,9 +37,9 @@ The runtime layer does not replace transports, telemetry, storage, or structured
       code: "CapabilityPolicy",
     },
     {
-      title: "Replay",
-      text: "Emit stable events and durable reports for UIs, CLIs, tests, and local inspection tools.",
-      code: "RunEvent",
+      title: "Reports and regression",
+      text: "Replay recorded facts safely and compare normalized reports without repeating model or tool calls.",
+      code: "diff_run_reports",
     },
   ]}
 />
@@ -502,7 +503,7 @@ Applications can implement their own sinks for terminal rendering, WebSocket fan
 
 An event sink observes execution; it does not authorize it. Approval decisions still flow through the configured approval handler, while sinks distribute the resulting lifecycle to interested consumers.
 
-## Run Reports And Replay
+## Run Reports, Replay, And Regression Diffing
 
 `RunReport` is the durable app-facing summary built from normalized events. It collects context manifests, action records, approval checkpoints, artifacts, LLM metrics, and the final serialized task when the final stream event includes it.
 
@@ -534,6 +535,63 @@ assert_budget_under(replay, max_total_tokens=8_000)
 
 `RunReplay` never re-executes tools or model calls. It is a read-only view over report events with helpers such as `event_types`, `iter_events()`, and `find_events("context.prepared")`.
 
+### Comparing Run Reports
+
+Execute a baseline and candidate separately, then compare their recorded reports. Final reports are the usual regression input, but the comparison helpers do not inspect or enforce a task lifecycle state:
+
+```python
+from protolink import (
+    RunReportDiffConfig,
+    RunReportTolerance,
+    assert_run_matches,
+    diff_run_reports,
+    normalize_run_report,
+)
+
+config = RunReportDiffConfig(
+    ignore_paths=("/metadata/build_host",),
+    tolerances=(
+        # These application-owned scores are 0.910 and 0.915 in the reports.
+        RunReportTolerance(
+            "/metadata/evaluation_score",
+            absolute_tolerance=0.01,
+        ),
+    ),
+)
+normalized_baseline = normalize_run_report(baseline_report, config=config)
+comparison = diff_run_reports(baseline_report, candidate_report, config=config)
+
+if not comparison.matches:
+    print(comparison.format())
+
+# Convenient in a regression test: raises with a formatted, redacted summary.
+assert_run_matches(baseline_report, candidate_report, config=config)
+```
+
+The comparison canonicalizes known identifiers, timestamps, and sequence counters in ProtoLink-owned report envelopes. Recognized task-stream events also normalize runtime-derived summaries and timing values. Application-owned values inside tool payloads and report metadata remain exact unless they match an explicit ignore or tolerance rule. The result contains `matches`, `changed_sections`, and path-level `differences`.
+
+`RunReportDiffConfig(sections=..., normalize_volatile=True, ignore_paths=(), tolerances=())` controls the comparison. Each `RunReportTolerance(path, absolute_tolerance=0.0, relative_tolerance=0.0)` allows bounded numeric variation at one selected path; rules are checked in declaration order and the first match wins. An explicit tolerance takes precedence over built-in volatile normalization for the selected numeric value, so a test can opt a timing field back into bounded comparison. Defaults remain strict for fields that are not part of the built-in volatile-field normalization.
+
+Ignore and tolerance paths use RFC 6901 JSON Pointer syntax. `*` is ProtoLink's extension and matches exactly one path segment, so `/metrics/*/usage/total_tokens` covers every metric item's token count. `**` has no recursive meaning; it is a literal segment. Bracket notation is not interpreted either: `/events[0]/type` addresses a literal top-level key named `events[0]`, not item zero of `events`. Use `/events/0/type` for that list item.
+
+This is comparison, not execution. Neither `diff_run_reports()` nor `assert_run_matches()` invokes an agent, model, tool, transport, or external service. For a reproducible regression test, run the candidate against the same input with mock, captured, or otherwise controlled dependencies; with live dependencies, the diff is still useful evidence of what changed but does not make the run deterministic.
+
+The public comparison surface is:
+
+| API | Contract |
+|------|----------|
+| `ALL_RUN_REPORT_SECTIONS` | Default section tuple: `context`, `context_manifests`, `events`, `actions`, `approvals`, `artifacts`, `metrics`, `final_task`, and `metadata`. The report object's root `created_at` field is not part of this projection. |
+| `normalize_run_report(source, config=...)` | Return a new normalized dictionary without mutating the source. Accepts a `RunReport`, `RunReplay`, serialized report mapping, or iterable of `RunEvent` objects/dictionaries. |
+| `RunReportDiffConfig` | Select sections, enable or disable built-in volatile-field normalization, ignore pointer patterns, and attach numeric tolerances. |
+| `RunReportTolerance` | Define the absolute and/or relative numeric tolerance for one pointer pattern. Booleans are not treated as numbers. |
+| `diff_run_reports(baseline, candidate, config=...)` | Return a `RunReportDiff` containing the complete structured comparison. |
+| `RunReportDifference` | One `added`, `removed`, or `changed` value with its report section, RFC 6901 path, and available baseline/candidate value. Missing and explicit `None` remain distinct. |
+| `RunReportDiff` | Exposes `matches`, `differences`, `changed_sections`, `compared_sections`, `ignored_paths`, `format()`, and `to_dict()`. |
+| `RunReportSection`, `RunReportDifferenceKind`, `RunReportSource` | Public typing aliases for section names, difference kinds, and accepted comparison inputs. |
+| `assert_run_matches(...)` | Return the successful `RunReportDiff`, or raise `AssertionError` with `RunReportDiff.format()` when differences exist. |
+
+Core serialization is intentionally explicit about secrets. `RunReportDifference.to_dict()` always returns its raw fields, and `RunReportDiff.to_dict()` returns raw compared values unless a policy is supplied. Pass `redaction_policy=RedactionPolicy()` to `RunReportDiff.to_dict()` before exporting it. `RunReportDiff.format()` and the `assert_run_matches()` failure message apply the default redaction policy unless explicitly disabled. The `protolink run diff` text and JSON views also redact difference values by default.
+
 The assertion helpers are intentionally small:
 
 | Helper | Use |
@@ -541,6 +599,7 @@ The assertion helpers are intentionally small:
 | `assert_run_events(...)` | Verify that stable event types appeared, either exactly or as an ordered subsequence. |
 | `assert_no_denied_actions(...)` | Fail if policy, approval, or action events denied runtime work. |
 | `assert_budget_under(...)` | Aggregate report metrics and context manifests, then fail if token or runtime limits are exceeded. |
+| `assert_run_matches(...)` | Normalize and compare a baseline and candidate report, then fail with a formatted, redacted difference summary. |
 
 Use `RedactionPolicy` whenever persisting reports, approval payloads, context manifests, or telemetry data. The default policy masks common fields such as API keys, tokens, passwords, secrets, authorization headers, and credentials.
 

--- a/docs/content/whitepaper.md
+++ b/docs/content/whitepaper.md
@@ -857,7 +857,7 @@ state, and replay surfaces apply.
 That keeps deterministic orchestration on the same A2A-based model as the rest
 of the agent mesh.
 
-## Telemetry, Events, Reports, And Replay
+## Telemetry, Events, Reports, Replay, And Regression Diffing
 
 ProtoLink separates live application events from observability traces.
 
@@ -909,27 +909,53 @@ Promoted event types include:
 built-in sink for tests and local apps. `RunRecorder` records a stream and turns
 it into a `RunReport`. `RunReplay` provides a read-only view over that report.
 
-This makes golden-run testing practical:
+This makes event assertions and golden-run regression testing practical. The
+baseline and candidate are executed and recorded separately:
 
 ```python
-from protolink import RunRecorder, RunReplay, assert_run_events
+from protolink import (
+    RunRecorder,
+    RunReplay,
+    assert_run_events,
+    assert_run_matches,
+    diff_run_reports,
+)
 
-recorder = RunRecorder(context=context)
+baseline_recorder = RunRecorder(context=baseline_context)
 
-async for task_event in agent.handle_task_streaming(task):
-    await recorder.record_task_event(task_event)
+async for task_event in baseline_agent.handle_task_streaming(baseline_task):
+    await baseline_recorder.record_task_event(task_event)
 
-report = recorder.to_report()
-replay = RunReplay(report)
+baseline_report = baseline_recorder.to_report()
+replay = RunReplay(baseline_report)
 
 assert_run_events(
     replay,
     ["task.status", "context.prepared", "llm.call.started", "llm.call.completed", "task.status"],
 )
+
+# Execute the changed agent separately against controlled model/tool dependencies.
+candidate_recorder = RunRecorder(context=candidate_context)
+async for task_event in candidate_agent.handle_task_streaming(candidate_task):
+    await candidate_recorder.record_task_event(task_event)
+candidate_report = candidate_recorder.to_report()
+
+comparison = diff_run_reports(baseline_report, candidate_report)
+if not comparison.matches:
+    print(comparison.format())
+assert_run_matches(baseline_report, candidate_report)
 ```
 
 Replay does not re-execute tools or model calls. It lets applications inspect
-what happened through a durable, redacted, structured summary.
+what happened through a durable, structured summary that can be redacted before
+persistence or rendering. Regression diffing also operates only on already
+recorded data: it canonicalizes known ProtoLink runtime-envelope identifiers,
+timestamps, sequence counters, and derived timing fields, then compares event,
+action, approval, artifact, metric, and final-task content. Application-owned
+payloads remain exact. Final reports are the normal regression input, although
+the comparison API does not enforce a task lifecycle state. Deterministic tests
+still require controlled or captured model, tool, and external-service
+responses.
 
 ## State And Memory
 
@@ -1048,10 +1074,11 @@ summaries, causal IDs, and replay compatibility.
 
 ### Testing
 
-Use `MockLLM`, `RuntimeTransport`, `InMemoryEventSink`, `RunRecorder`, and
-golden-run assertions to test agent behavior without live providers or network
-ports. This is especially valuable because the runtime records concrete action
-and policy events rather than relying on text snapshots alone.
+Use `MockLLM`, `RuntimeTransport`, `InMemoryEventSink`, `RunRecorder`,
+`diff_run_reports()`, and golden-run assertions to test agent behavior without
+live providers or network ports. This is especially valuable because the
+runtime records concrete action and policy events rather than relying on text
+snapshots alone.
 
 ## What ProtoLink Brings To The Table
 

--- a/examples/run_regression_diff.py
+++ b/examples/run_regression_diff.py
@@ -1,0 +1,168 @@
+"""Protolink 0.6.6 normalized run-report regression diffing.
+
+This provider-free example builds completed reports directly so it can show the
+comparison contract without calling a model, tool, transport, or external
+service. A real application would record each run with ``RunRecorder`` and keep
+the baseline report in a ``RunStore`` or test fixture.
+
+Run it with:
+
+    python examples/run_regression_diff.py
+"""
+
+from __future__ import annotations
+
+from protolink import (
+    Message,
+    Part,
+    RunContext,
+    RunEvent,
+    RunReport,
+    RunReportDiffConfig,
+    RunReportTolerance,
+    Task,
+    TaskState,
+    assert_run_matches,
+    diff_run_reports,
+)
+
+REGRESSION_CONFIG = RunReportDiffConfig(
+    tolerances=(
+        # Explicit rules opt these otherwise volatile timings back into a
+        # bounded comparison.
+        RunReportTolerance(
+            "/events/*/payload/latency_ms",
+            absolute_tolerance=50.0,
+        ),
+        RunReportTolerance(
+            "/metrics/*/latency_ms",
+            absolute_tolerance=50.0,
+        ),
+    )
+)
+
+
+def build_report(
+    *,
+    label: str,
+    answer: str,
+    latency_ms: float,
+    sequence_start: int,
+    timestamp: str,
+) -> RunReport:
+    """Build one completed report with deliberately volatile execution fields."""
+    task = Task(
+        id=f"task_{label}",
+        state=TaskState.COMPLETED,
+        messages=[
+            Message(
+                id=f"message_{label}",
+                role="agent",
+                parts=[Part.text(answer)],
+                timestamp=timestamp,
+            )
+        ],
+        created_at=timestamp,
+    )
+    context = RunContext(
+        run_id=f"run_{label}",
+        session_id="regression-demo",
+        trace_id=f"trace_{label}",
+        agent_chain=["regression-agent"],
+        created_at=timestamp,
+    )
+    context.attach_to_task(task)
+    final_task = task.to_dict()
+    events = [
+        RunEvent(
+            event_id=f"event_llm_{label}",
+            type="llm.call.completed",
+            run_id=context.run_id,
+            task_id=task.id,
+            agent_name="regression-agent",
+            sequence=sequence_start,
+            summary="Model call completed",
+            payload={"provider": "mock", "model": "regression-fixture", "latency_ms": latency_ms},
+            metadata={"source_type": "task_llm_stream"},
+            timestamp=timestamp,
+        ),
+        RunEvent(
+            event_id=f"event_task_{label}",
+            type="task.status",
+            run_id=context.run_id,
+            task_id=task.id,
+            agent_name="regression-agent",
+            sequence=sequence_start + 1,
+            summary="Task completed",
+            payload={"state": "completed", "metadata": {"task": final_task}},
+            final=True,
+            metadata={"source_type": "task_status_update"},
+            timestamp=timestamp,
+        ),
+    ]
+    return RunReport.from_events(
+        events,
+        context=context,
+        final_task=final_task,
+        metadata={"suite": "provider-free-regression-example"},
+    )
+
+
+def main() -> None:
+    """Show volatile-field normalization and a real behavioral difference."""
+    baseline = build_report(
+        label="baseline",
+        answer="The approved total is 42.",
+        latency_ms=100.0,
+        sequence_start=1,
+        timestamp="2026-07-17T09:00:00Z",
+    )
+    equivalent_candidate = build_report(
+        label="candidate_same",
+        answer="The approved total is 42.",
+        latency_ms=125.0,
+        sequence_start=101,
+        timestamp="2026-07-17T09:05:00Z",
+    )
+
+    equivalent = diff_run_reports(
+        baseline,
+        equivalent_candidate,
+        config=REGRESSION_CONFIG,
+    )
+    assert equivalent.matches
+    assert_run_matches(
+        baseline,
+        equivalent_candidate,
+        config=REGRESSION_CONFIG,
+    )
+    print("Equivalent candidate:", "MATCH")
+
+    changed_candidate = build_report(
+        label="candidate_changed",
+        answer="The approved total is 43.",
+        latency_ms=125.0,
+        sequence_start=201,
+        timestamp="2026-07-17T09:10:00Z",
+    )
+    changed = diff_run_reports(
+        baseline,
+        changed_candidate,
+        config=REGRESSION_CONFIG,
+    )
+    assert not changed.matches
+    print("Changed candidate:", "CHANGED")
+    print(changed.format(max_differences=5))
+
+    try:
+        assert_run_matches(
+            baseline,
+            changed_candidate,
+            config=REGRESSION_CONFIG,
+        )
+    except AssertionError as exc:
+        print("Regression assertion:", str(exc).splitlines()[0])
+
+
+if __name__ == "__main__":
+    main()

--- a/protolink/__init__.py
+++ b/protolink/__init__.py
@@ -3,6 +3,7 @@
 from protolink.__version__ import __version__
 from protolink.agents import Agent
 from protolink.core import (
+    ALL_RUN_REPORT_SECTIONS,
     DEFAULT_REDACTION_POLICY,
     ActionAuthorization,
     ActionAuthorizer,
@@ -33,6 +34,13 @@ from protolink.core import (
     RunRecorder,
     RunReplay,
     RunReport,
+    RunReportDiff,
+    RunReportDiffConfig,
+    RunReportDifference,
+    RunReportDifferenceKind,
+    RunReportSection,
+    RunReportSource,
+    RunReportTolerance,
     TaskAlreadyRunningError,
     TaskCancellationError,
     TaskCancellationRequest,
@@ -41,6 +49,9 @@ from protolink.core import (
     assert_budget_under,
     assert_no_denied_actions,
     assert_run_events,
+    assert_run_matches,
+    diff_run_reports,
+    normalize_run_report,
 )
 from protolink.flows import Flow, Graph, Parallel, Pipeline, Router
 from protolink.llms import (
@@ -74,6 +85,7 @@ from protolink.transport import (
 )
 
 __all__ = [
+    "ALL_RUN_REPORT_SECTIONS",
     "DEFAULT_REDACTION_POLICY",
     "ActionAuthorization",
     "ActionAuthorizer",
@@ -127,7 +139,14 @@ __all__ = [
     "RunRecorder",
     "RunReplay",
     "RunReport",
+    "RunReportDiff",
+    "RunReportDiffConfig",
+    "RunReportDifference",
+    "RunReportDifferenceKind",
     "RunReportRecord",
+    "RunReportSection",
+    "RunReportSource",
+    "RunReportTolerance",
     "RunStore",
     "SQLiteRunStore",
     "StateOperationRequest",
@@ -156,6 +175,9 @@ __all__ = [
     "assert_budget_under",
     "assert_no_denied_actions",
     "assert_run_events",
+    "assert_run_matches",
     "build_context_manifest",
     "create_llm",
+    "diff_run_reports",
+    "normalize_run_report",
 ]

--- a/protolink/cli.py
+++ b/protolink/cli.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 from protolink.devtools import (
     build_doctor_report,
+    build_run_diff_view,
     build_run_replay_view,
     fetch_registry_agents,
     inspect_registry_agent,
@@ -95,6 +96,15 @@ def _build_parser() -> argparse.ArgumentParser:
     run_replay_parser.add_argument("run_id", help="Run ID or task ID.")
     run_replay_parser.add_argument("--store", default="runs.db", help="SQLite run-store path.")
     run_replay_parser.add_argument("--json", action="store_true", help="Emit JSON instead of text.")
+
+    run_diff_parser = run_subparsers.add_parser(
+        "diff",
+        help="Compare two stored run reports after normalizing volatile fields.",
+    )
+    run_diff_parser.add_argument("baseline_run_id", help="Baseline run-report ID.")
+    run_diff_parser.add_argument("candidate_run_id", help="Candidate run-report ID.")
+    run_diff_parser.add_argument("--store", default="runs.db", help="SQLite run-store path.")
+    run_diff_parser.add_argument("--json", action="store_true", help="Emit JSON instead of text.")
 
     dashboard_parser = subparsers.add_parser("dashboard", help="Open the local Protolink dashboard.")
     dashboard_parser.add_argument("--registry-url", help="Optional HTTP registry URL.")
@@ -216,6 +226,20 @@ def main(argv: list[str] | None = None) -> int:
         else:
             print(text_renderer.render_run_replay(view))
         return 1 if view.source == "missing" else 0
+
+    if args.command == "run" and args.run_command == "diff":
+        view = build_run_diff_view(
+            args.store,
+            args.baseline_run_id,
+            args.candidate_run_id,
+        )
+        if args.json:
+            print(json.dumps(view.to_dict(), indent=2))
+        else:
+            print(text_renderer.render_run_diff(view))
+        if view.status == "missing":
+            return 2
+        return 0 if view.status == "match" else 1
 
     if args.command == "dashboard":
         html_renderer = DevtoolsHtmlRenderer()

--- a/protolink/core/__init__.py
+++ b/protolink/core/__init__.py
@@ -41,9 +41,23 @@ from protolink.core.report import (
     assert_no_denied_actions,
     assert_run_events,
 )
+from protolink.core.report_diff import (
+    ALL_RUN_REPORT_SECTIONS,
+    RunReportDiff,
+    RunReportDiffConfig,
+    RunReportDifference,
+    RunReportDifferenceKind,
+    RunReportSection,
+    RunReportSource,
+    RunReportTolerance,
+    assert_run_matches,
+    diff_run_reports,
+    normalize_run_report,
+)
 from protolink.core.run_context import RunBudget, RunContext
 
 __all__ = [
+    "ALL_RUN_REPORT_SECTIONS",
     "DEFAULT_REDACTION_POLICY",
     "ActionAuthorization",
     "ActionAuthorizer",
@@ -74,6 +88,13 @@ __all__ = [
     "RunRecorder",
     "RunReplay",
     "RunReport",
+    "RunReportDiff",
+    "RunReportDiffConfig",
+    "RunReportDifference",
+    "RunReportDifferenceKind",
+    "RunReportSection",
+    "RunReportSource",
+    "RunReportTolerance",
     "TaskAlreadyRunningError",
     "TaskCancellationError",
     "TaskCancellationRequest",
@@ -82,4 +103,7 @@ __all__ = [
     "assert_budget_under",
     "assert_no_denied_actions",
     "assert_run_events",
+    "assert_run_matches",
+    "diff_run_reports",
+    "normalize_run_report",
 ]

--- a/protolink/core/report_diff.py
+++ b/protolink/core/report_diff.py
@@ -1,0 +1,1115 @@
+"""Normalized run-report comparison for regression testing.
+
+The helpers in this module compare two :class:`RunReport` objects, typically
+captured after their runs finish.
+They do not execute agents, models, tools, transports, or side effects. Runtime
+generated identifiers and timestamps are normalized inside known ProtoLink
+envelopes so a fresh candidate run can be compared with a stored baseline
+without hiding application-owned identifiers in tool payloads.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+from decimal import Decimal, InvalidOperation
+from difflib import SequenceMatcher
+from typing import Any, Literal, TypeAlias, cast
+
+from protolink.core.events import RunEvent
+from protolink.core.redaction import DEFAULT_REDACTION_POLICY, RedactionPolicy
+from protolink.core.report import RunReplay, RunReport
+
+RunReportSection = Literal[
+    "context",
+    "context_manifests",
+    "events",
+    "actions",
+    "approvals",
+    "artifacts",
+    "metrics",
+    "final_task",
+    "metadata",
+]
+"""Sections of a durable run report that can participate in a comparison."""
+
+RunReportDifferenceKind = Literal["added", "removed", "changed"]
+"""Kinds of structural differences emitted by :func:`diff_run_reports`."""
+
+RunReportSource: TypeAlias = RunReport | RunReplay | Mapping[str, Any] | Iterable[RunEvent | dict[str, Any]]
+"""Input shapes accepted by the run-report comparison helpers."""
+
+ALL_RUN_REPORT_SECTIONS: tuple[RunReportSection, ...] = (
+    "context",
+    "context_manifests",
+    "events",
+    "actions",
+    "approvals",
+    "artifacts",
+    "metrics",
+    "final_task",
+    "metadata",
+)
+"""Default report sections compared by :func:`diff_run_reports`."""
+
+_MISSING = object()
+_SKIP = object()
+
+
+@dataclass(frozen=True)
+class RunReportTolerance:
+    """Numeric tolerance applied to values at one report path.
+
+    ``path`` is an RFC 6901 JSON Pointer pattern. The ``*`` segment extension
+    matches exactly one dictionary key or list index, for example
+    ``/events/*/payload/latency_ms``. Rules are evaluated in declaration order
+    and the first matching rule wins.
+
+    Args:
+        path: JSON Pointer pattern identifying numeric values.
+        absolute_tolerance: Maximum absolute difference accepted by
+            :func:`math.isclose`.
+        relative_tolerance: Maximum relative difference accepted by
+            :func:`math.isclose`.
+    """
+
+    path: str
+    absolute_tolerance: float = 0.0
+    relative_tolerance: float = 0.0
+
+    def __post_init__(self) -> None:
+        """Validate the path pattern and tolerance values."""
+        _parse_pointer_pattern(self.path)
+        for name, value in (
+            ("absolute_tolerance", self.absolute_tolerance),
+            ("relative_tolerance", self.relative_tolerance),
+        ):
+            numeric = float(value)
+            if not math.isfinite(numeric) or numeric < 0:
+                raise ValueError(f"{name} must be a finite non-negative number")
+            object.__setattr__(self, name, numeric)
+
+
+@dataclass(frozen=True)
+class RunReportDiffConfig:
+    """Configuration for normalized run-report comparison.
+
+    Args:
+        sections: Report sections to compare.
+        normalize_volatile: Canonicalize known runtime-generated identifiers
+            and timestamps. Application-owned values inside tool payloads and
+            report metadata remain exact.
+        ignore_paths: Additional RFC 6901 JSON Pointer patterns to omit. A
+            ``*`` segment matches exactly one key or index. Ignoring a
+            container omits its complete subtree.
+        tolerances: Ordered numeric tolerance rules. Booleans are never treated
+            as numbers.
+    """
+
+    sections: tuple[RunReportSection, ...] = ALL_RUN_REPORT_SECTIONS
+    normalize_volatile: bool = True
+    ignore_paths: tuple[str, ...] = ()
+    tolerances: tuple[RunReportTolerance, ...] = ()
+
+    def __post_init__(self) -> None:
+        """Normalize iterable inputs and validate public configuration."""
+        sections = tuple(self.sections)
+        unknown = tuple(section for section in sections if section not in ALL_RUN_REPORT_SECTIONS)
+        if unknown:
+            raise ValueError(f"Unknown run-report sections: {unknown!r}")
+        if len(set(sections)) != len(sections):
+            raise ValueError("Run-report sections must not contain duplicates")
+
+        ignore_paths = tuple(str(path) for path in self.ignore_paths)
+        for path in ignore_paths:
+            _parse_pointer_pattern(path)
+
+        tolerances = tuple(self.tolerances)
+        if any(not isinstance(tolerance, RunReportTolerance) for tolerance in tolerances):
+            raise TypeError("tolerances must contain RunReportTolerance objects")
+
+        object.__setattr__(self, "sections", sections)
+        object.__setattr__(self, "ignore_paths", ignore_paths)
+        object.__setattr__(self, "tolerances", tolerances)
+
+
+@dataclass(frozen=True)
+class RunReportDifference:
+    """One structured difference between normalized report projections."""
+
+    section: RunReportSection
+    path: str
+    kind: RunReportDifferenceKind
+    baseline: Any = field(default=_MISSING, repr=False)
+    candidate: Any = field(default=_MISSING, repr=False)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize this difference without conflating missing and ``None``."""
+        data: dict[str, Any] = {
+            "section": self.section,
+            "path": self.path,
+            "kind": self.kind,
+        }
+        if self.baseline is not _MISSING:
+            data["baseline"] = self.baseline
+        if self.candidate is not _MISSING:
+            data["candidate"] = self.candidate
+        return data
+
+
+@dataclass(frozen=True)
+class RunReportDiff:
+    """Structured result of comparing a baseline and candidate report."""
+
+    differences: tuple[RunReportDifference, ...] = ()
+    compared_sections: tuple[RunReportSection, ...] = ALL_RUN_REPORT_SECTIONS
+    ignored_paths: tuple[str, ...] = ()
+
+    @property
+    def matches(self) -> bool:
+        """Return whether the normalized reports contain no differences."""
+        return not self.differences
+
+    @property
+    def changed_sections(self) -> tuple[RunReportSection, ...]:
+        """Return changed sections in comparison order."""
+        changed = {difference.section for difference in self.differences}
+        return tuple(section for section in self.compared_sections if section in changed)
+
+    def to_dict(
+        self,
+        *,
+        redaction_policy: RedactionPolicy | None = None,
+    ) -> dict[str, Any]:
+        """Serialize the result, optionally masking secrets in diff values."""
+        serialized_differences = [difference.to_dict() for difference in self.differences]
+        if redaction_policy is not None:
+            serialized_differences = [
+                _redact_difference(difference, redaction_policy) for difference in serialized_differences
+            ]
+        data = {
+            "matches": self.matches,
+            "difference_count": len(self.differences),
+            "changed_sections": list(self.changed_sections),
+            "compared_sections": list(self.compared_sections),
+            "ignored_paths": list(self.ignored_paths),
+            "differences": serialized_differences,
+        }
+        return data
+
+    def format(
+        self,
+        *,
+        max_differences: int = 20,
+        redaction_policy: RedactionPolicy | None = DEFAULT_REDACTION_POLICY,
+    ) -> str:
+        """Render a concise deterministic summary for terminals and assertions."""
+        if max_differences < 0:
+            raise ValueError("max_differences must be non-negative")
+        if self.matches:
+            return "Run reports match after normalization."
+
+        serialized = self.to_dict(redaction_policy=redaction_policy)
+        serialized_differences = serialized["differences"]
+        section_text = ", ".join(self.changed_sections)
+        lines = [
+            f"Run reports differ: {len(self.differences)} difference(s) across {section_text}.",
+        ]
+        for difference in serialized_differences[:max_differences]:
+            kind = str(difference["kind"]).upper()
+            detail = _format_difference_values(difference)
+            lines.append(f"- {kind} {difference['path']}{detail}")
+        remaining = len(self.differences) - min(len(self.differences), max_differences)
+        if remaining:
+            lines.append(f"... {remaining} additional difference(s) omitted.")
+        return "\n".join(lines)
+
+
+def normalize_run_report(
+    source: RunReportSource,
+    *,
+    config: RunReportDiffConfig | None = None,
+) -> dict[str, Any]:
+    """Return a deterministic report projection suitable for comparison.
+
+    The source is never mutated. Known runtime identifiers are canonicalized
+    per report so their relationships remain visible while freshly generated
+    values do not create false regressions.
+    """
+    active_config = config or RunReportDiffConfig()
+    report = _coerce_report(source)
+    serialized = report.to_dict()
+    projection = {section: serialized.get(section) for section in active_config.sections}
+    normalizer = _ReportNormalizer(active_config)
+    normalizer.prepare_identifier_occurrences(projection)
+    normalized = normalizer.normalize(projection)
+    if normalized is _SKIP:
+        return {}
+    if not isinstance(normalized, dict):  # pragma: no cover - projection is always a dict
+        raise TypeError("Normalized run-report projection must be a dictionary")
+    return normalized
+
+
+def diff_run_reports(
+    baseline: RunReportSource,
+    candidate: RunReportSource,
+    *,
+    config: RunReportDiffConfig | None = None,
+) -> RunReportDiff:
+    """Compare baseline and candidate run reports after normalization."""
+    active_config = config or RunReportDiffConfig()
+    baseline_projection = normalize_run_report(baseline, config=active_config)
+    candidate_projection = normalize_run_report(candidate, config=active_config)
+    differences: list[RunReportDifference] = []
+    _diff_values(
+        baseline_projection,
+        candidate_projection,
+        path=(),
+        config=active_config,
+        differences=differences,
+    )
+    return RunReportDiff(
+        differences=tuple(differences),
+        compared_sections=active_config.sections,
+        ignored_paths=active_config.ignore_paths,
+    )
+
+
+def assert_run_matches(
+    baseline: RunReportSource,
+    candidate: RunReportSource,
+    *,
+    config: RunReportDiffConfig | None = None,
+) -> RunReportDiff:
+    """Assert that two run reports match after normalization.
+
+    Returns:
+        The successful structured comparison result.
+
+    Raises:
+        AssertionError: The normalized reports differ.
+    """
+    result = diff_run_reports(baseline, candidate, config=config)
+    if not result.matches:
+        raise AssertionError(result.format())
+    return result
+
+
+class _ReportNormalizer:
+    """Recursively normalize one report projection without mutating it."""
+
+    def __init__(self, config: RunReportDiffConfig) -> None:
+        self.config = config
+        self.ignore_patterns = tuple(_parse_pointer_pattern(path) for path in config.ignore_paths)
+        self.identifiers: dict[str, dict[str, str]] = {}
+        self.identifier_occurrences: dict[tuple[str, str], int] = {}
+
+    def prepare_identifier_occurrences(self, value: Any) -> None:
+        """Count equality groups before replacing volatile identifiers."""
+        self.identifier_occurrences.clear()
+        self._count_identifier_occurrences(value)
+
+    def _count_identifier_occurrences(
+        self,
+        value: Any,
+        path: tuple[str, ...] = (),
+        *,
+        runtime_event: bool = False,
+    ) -> None:
+        if self._ignored(path):
+            return
+
+        if isinstance(value, Mapping) and len(path) == 2 and path[0] == "events":
+            runtime_event = _is_runtime_event_mapping(value)
+
+        if self.config.normalize_volatile:
+            category = _volatile_identifier_category(path, runtime_event=runtime_event)
+            if category is not None and value is not None:
+                namespace = _identifier_namespace(category)
+                key = (namespace, _canonical_json(value))
+                self.identifier_occurrences[key] = self.identifier_occurrences.get(key, 0) + 1
+                return
+
+        if isinstance(value, Mapping):
+            for raw_key in sorted(value, key=lambda item: str(item)):
+                self._count_identifier_occurrences(
+                    value[raw_key],
+                    (*path, str(raw_key)),
+                    runtime_event=runtime_event,
+                )
+            return
+
+        if isinstance(value, (list, tuple)):
+            for index, item in enumerate(value):
+                self._count_identifier_occurrences(
+                    item,
+                    (*path, str(index)),
+                    runtime_event=runtime_event,
+                )
+
+    def normalize(
+        self,
+        value: Any,
+        path: tuple[str, ...] = (),
+        *,
+        runtime_event: bool = False,
+    ) -> Any:
+        """Normalize one value at ``path``."""
+        if self._ignored(path):
+            return _SKIP
+
+        if isinstance(value, Mapping) and len(path) == 2 and path[0] == "events":
+            runtime_event = _is_runtime_event_mapping(value)
+
+        if self.config.normalize_volatile:
+            category = _volatile_identifier_category(path, runtime_event=runtime_event)
+            if category is not None and value is not None:
+                return self._canonical_identifier(category, value)
+            if _is_volatile_scalar(path, runtime_event=runtime_event) and value is not None:
+                explicitly_tolerated = (
+                    _is_number(value) and _tolerance_for_path(path, self.config.tolerances) is not None
+                )
+                if not explicitly_tolerated:
+                    return f"<{_volatile_scalar_label(path, runtime_event=runtime_event)}>"
+
+        if isinstance(value, Mapping):
+            result: dict[str, Any] = {}
+            for raw_key in sorted(value, key=lambda item: str(item)):
+                key = str(raw_key)
+                normalized = self.normalize(
+                    value[raw_key],
+                    (*path, key),
+                    runtime_event=runtime_event,
+                )
+                if normalized is not _SKIP:
+                    result[key] = normalized
+            return result
+
+        if isinstance(value, (list, tuple)):
+            result_list: list[Any] = []
+            for index, item in enumerate(value):
+                normalized = self.normalize(
+                    item,
+                    (*path, str(index)),
+                    runtime_event=runtime_event,
+                )
+                if normalized is not _SKIP:
+                    result_list.append(normalized)
+            return result_list
+
+        if isinstance(value, (set, frozenset)):
+            normalized_items = [
+                self.normalize(
+                    item,
+                    (*path, "*"),
+                    runtime_event=runtime_event,
+                )
+                for item in value
+            ]
+            return sorted(
+                (item for item in normalized_items if item is not _SKIP),
+                key=_canonical_json,
+            )
+
+        return _json_compatible_scalar(value)
+
+    def _ignored(self, path: tuple[str, ...]) -> bool:
+        if not path:
+            return False
+        return any(_pattern_matches_prefix(pattern, path) for pattern in self.ignore_patterns)
+
+    def _canonical_identifier(self, category: str, value: Any) -> str:
+        category = _identifier_namespace(category)
+        serialized = _canonical_json(value)
+        if self.identifier_occurrences.get((category, serialized), 1) < 2:
+            # Opaque singleton IDs do not carry a relationship. Keeping one
+            # constant per namespace also prevents unrelated insertions from
+            # renumbering later aligned items.
+            return f"<{category}>"
+        category_values = self.identifiers.setdefault(category, {})
+        if serialized not in category_values:
+            category_values[serialized] = f"<{category}:{len(category_values) + 1}>"
+        return category_values[serialized]
+
+
+def _coerce_report(source: RunReportSource) -> RunReport:
+    if isinstance(source, RunReplay):
+        return source.report
+    if isinstance(source, RunReport):
+        return source
+    if isinstance(source, Mapping):
+        return RunReport.from_dict({str(key): value for key, value in source.items()})
+    if isinstance(source, (str, bytes)):
+        raise TypeError("Run-report sources cannot be strings or bytes")
+    try:
+        return RunReport.from_events(source)
+    except TypeError as exc:
+        raise TypeError("Expected RunReport, RunReplay, serialized report mapping, or run-event iterable") from exc
+
+
+def _diff_values(
+    baseline: Any,
+    candidate: Any,
+    *,
+    path: tuple[str, ...],
+    config: RunReportDiffConfig,
+    differences: list[RunReportDifference],
+) -> None:
+    if isinstance(baseline, dict) and isinstance(candidate, dict):
+        keys = sorted(set(baseline).union(candidate))
+        for key in keys:
+            child_path = (*path, key)
+            if key not in baseline:
+                _append_difference(
+                    differences,
+                    path=child_path,
+                    kind="added",
+                    candidate=candidate[key],
+                )
+            elif key not in candidate:
+                _append_difference(
+                    differences,
+                    path=child_path,
+                    kind="removed",
+                    baseline=baseline[key],
+                )
+            else:
+                _diff_values(
+                    baseline[key],
+                    candidate[key],
+                    path=child_path,
+                    config=config,
+                    differences=differences,
+                )
+        return
+
+    if isinstance(baseline, list) and isinstance(candidate, list):
+        if _uses_semantic_alignment(path):
+            _diff_aligned_sequences(
+                baseline,
+                candidate,
+                path=path,
+                config=config,
+                differences=differences,
+            )
+        else:
+            _diff_positional_sequences(
+                baseline,
+                candidate,
+                path=path,
+                config=config,
+                differences=differences,
+            )
+        return
+
+    if _values_equal(baseline, candidate, path=path, config=config):
+        return
+    _append_difference(
+        differences,
+        path=path,
+        kind="changed",
+        baseline=baseline,
+        candidate=candidate,
+    )
+
+
+def _diff_positional_sequences(
+    baseline: Sequence[Any],
+    candidate: Sequence[Any],
+    *,
+    path: tuple[str, ...],
+    config: RunReportDiffConfig,
+    differences: list[RunReportDifference],
+) -> None:
+    shared = min(len(baseline), len(candidate))
+    for index in range(shared):
+        _diff_values(
+            baseline[index],
+            candidate[index],
+            path=(*path, str(index)),
+            config=config,
+            differences=differences,
+        )
+    for index in range(shared, len(baseline)):
+        _append_difference(
+            differences,
+            path=(*path, str(index)),
+            kind="removed",
+            baseline=baseline[index],
+        )
+    for index in range(shared, len(candidate)):
+        _append_difference(
+            differences,
+            path=(*path, str(index)),
+            kind="added",
+            candidate=candidate[index],
+        )
+
+
+def _diff_aligned_sequences(
+    baseline: Sequence[Any],
+    candidate: Sequence[Any],
+    *,
+    path: tuple[str, ...],
+    config: RunReportDiffConfig,
+    differences: list[RunReportDifference],
+) -> None:
+    baseline_base_keys = [_semantic_item_key(path, item) for item in baseline]
+    candidate_base_keys = [_semantic_item_key(path, item) for item in candidate]
+    repeated_keys = {
+        key
+        for key in set(baseline_base_keys).union(candidate_base_keys)
+        if baseline_base_keys.count(key) > 1 or candidate_base_keys.count(key) > 1
+    }
+    baseline_keys = [
+        (*key, _canonical_json(item)) if key in repeated_keys else key
+        for key, item in zip(baseline_base_keys, baseline, strict=True)
+    ]
+    candidate_keys = [
+        (*key, _canonical_json(item)) if key in repeated_keys else key
+        for key, item in zip(candidate_base_keys, candidate, strict=True)
+    ]
+    matcher = SequenceMatcher(None, baseline_keys, candidate_keys, autojunk=False)
+
+    for tag, baseline_start, baseline_end, candidate_start, candidate_end in matcher.get_opcodes():
+        if tag == "equal":
+            for baseline_index, candidate_index in zip(
+                range(baseline_start, baseline_end),
+                range(candidate_start, candidate_end),
+                strict=True,
+            ):
+                _diff_values(
+                    baseline[baseline_index],
+                    candidate[candidate_index],
+                    path=(*path, str(candidate_index)),
+                    config=config,
+                    differences=differences,
+                )
+            continue
+
+        if tag == "delete":
+            for baseline_index in range(baseline_start, baseline_end):
+                _append_difference(
+                    differences,
+                    path=(*path, str(baseline_index)),
+                    kind="removed",
+                    baseline=baseline[baseline_index],
+                )
+            continue
+
+        if tag == "insert":
+            for candidate_index in range(candidate_start, candidate_end):
+                _append_difference(
+                    differences,
+                    path=(*path, str(candidate_index)),
+                    kind="added",
+                    candidate=candidate[candidate_index],
+                )
+            continue
+
+        baseline_indexes = list(range(baseline_start, baseline_end))
+        candidate_indexes = list(range(candidate_start, candidate_end))
+        shared = min(len(baseline_indexes), len(candidate_indexes))
+        for offset in range(shared):
+            baseline_index = baseline_indexes[offset]
+            candidate_index = candidate_indexes[offset]
+            _diff_values(
+                baseline[baseline_index],
+                candidate[candidate_index],
+                path=(*path, str(candidate_index)),
+                config=config,
+                differences=differences,
+            )
+        for baseline_index in baseline_indexes[shared:]:
+            _append_difference(
+                differences,
+                path=(*path, str(baseline_index)),
+                kind="removed",
+                baseline=baseline[baseline_index],
+            )
+        for candidate_index in candidate_indexes[shared:]:
+            _append_difference(
+                differences,
+                path=(*path, str(candidate_index)),
+                kind="added",
+                candidate=candidate[candidate_index],
+            )
+
+
+def _append_difference(
+    differences: list[RunReportDifference],
+    *,
+    path: tuple[str, ...],
+    kind: RunReportDifferenceKind,
+    baseline: Any = _MISSING,
+    candidate: Any = _MISSING,
+) -> None:
+    if not path:
+        raise ValueError("Run-report differences require a section path")
+    section = cast(RunReportSection, path[0])
+    differences.append(
+        RunReportDifference(
+            section=section,
+            path=_json_pointer(path),
+            kind=kind,
+            baseline=baseline,
+            candidate=candidate,
+        )
+    )
+
+
+def _values_equal(
+    baseline: Any,
+    candidate: Any,
+    *,
+    path: tuple[str, ...],
+    config: RunReportDiffConfig,
+) -> bool:
+    if _is_number(baseline) and _is_number(candidate):
+        tolerance = _tolerance_for_path(path, config.tolerances)
+        if tolerance is None:
+            return bool(baseline == candidate)
+        return _numbers_close(baseline, candidate, tolerance)
+
+    if type(baseline) is not type(candidate):
+        return False
+
+    return bool(baseline == candidate)
+
+
+def _is_number(value: Any) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def _numbers_close(
+    baseline: int | float,
+    candidate: int | float,
+    tolerance: RunReportTolerance,
+) -> bool:
+    """Compare numeric values without coercing arbitrarily large integers."""
+    if baseline == candidate:
+        return True
+    if isinstance(baseline, float) and not math.isfinite(baseline):
+        return False
+    if isinstance(candidate, float) and not math.isfinite(candidate):
+        return False
+
+    try:
+        baseline_decimal = Decimal(str(baseline))
+        candidate_decimal = Decimal(str(candidate))
+        difference = abs(baseline_decimal - candidate_decimal)
+        scale = max(abs(baseline_decimal), abs(candidate_decimal))
+        allowed = max(
+            Decimal(str(tolerance.absolute_tolerance)),
+            Decimal(str(tolerance.relative_tolerance)) * scale,
+        )
+    except (InvalidOperation, ValueError):
+        return False
+
+    return difference <= allowed
+
+
+def _tolerance_for_path(
+    path: tuple[str, ...],
+    tolerances: tuple[RunReportTolerance, ...],
+) -> RunReportTolerance | None:
+    for tolerance in tolerances:
+        pattern = _parse_pointer_pattern(tolerance.path)
+        if _pattern_matches_exact(pattern, path):
+            return tolerance
+    return None
+
+
+def _uses_semantic_alignment(path: tuple[str, ...]) -> bool:
+    return path in {
+        ("context_manifests",),
+        ("events",),
+        ("actions",),
+        ("approvals",),
+        ("artifacts",),
+        ("metrics",),
+    }
+
+
+def _semantic_item_key(path: tuple[str, ...], item: Any) -> tuple[str, ...]:
+    if not isinstance(item, dict):
+        return ("value", _canonical_json(item))
+
+    section = path[0]
+    if section == "events":
+        payload = item.get("payload")
+        payload_dict = payload if isinstance(payload, dict) else {}
+        action = payload_dict.get("action")
+        if not isinstance(action, dict):
+            request = payload_dict.get("request")
+            action = request.get("action") if isinstance(request, dict) else None
+        action_dict = action if isinstance(action, dict) else {}
+        return tuple(
+            _stable_key_part(value)
+            for value in (
+                "event",
+                item.get("type"),
+                item.get("agent_name"),
+                item.get("step"),
+                payload_dict.get("llm_event_type"),
+                action_dict.get("kind"),
+                action_dict.get("name"),
+            )
+        )
+    if section == "actions":
+        return tuple(_stable_key_part(value) for value in ("action", item.get("kind"), item.get("name")))
+    if section == "approvals":
+        request = item.get("request")
+        request_dict = request if isinstance(request, dict) else {}
+        action = request_dict.get("action")
+        action_dict = action if isinstance(action, dict) else {}
+        return tuple(
+            _stable_key_part(value)
+            for value in (
+                "approval",
+                item.get("type"),
+                action_dict.get("kind"),
+                action_dict.get("name"),
+            )
+        )
+    if section == "artifacts":
+        return tuple(
+            _stable_key_part(value)
+            for value in (
+                "artifact",
+                item.get("kind"),
+                item.get("name"),
+                item.get("media_type"),
+            )
+        )
+    if section == "metrics":
+        return tuple(
+            _stable_key_part(value)
+            for value in (
+                "metric",
+                item.get("step"),
+                item.get("provider"),
+                item.get("model"),
+            )
+        )
+    return tuple(
+        _stable_key_part(value)
+        for value in (
+            "manifest",
+            item.get("agent_name"),
+            item.get("provider"),
+            item.get("model"),
+        )
+    )
+
+
+def _stable_key_part(value: Any) -> str:
+    return _canonical_json(value)
+
+
+def _format_difference_values(difference: dict[str, Any]) -> str:
+    values: list[str] = []
+    if "baseline" in difference:
+        values.append(f"baseline={_preview(difference['baseline'])}")
+    if "candidate" in difference:
+        values.append(f"candidate={_preview(difference['candidate'])}")
+    return ": " + ", ".join(values) if values else ""
+
+
+def _redact_difference(
+    difference: dict[str, Any],
+    policy: RedactionPolicy,
+) -> dict[str, Any]:
+    """Redact values while retaining the sensitive key encoded in ``path``."""
+    redacted = dict(difference)
+    path = str(difference.get("path") or "")
+    path_segments = (
+        tuple(segment.replace("~1", "/").replace("~0", "~") for segment in path[1:].split("/"))
+        if path.startswith("/")
+        else ()
+    )
+    sensitive_path = any(policy.is_sensitive_key(segment) for segment in path_segments)
+    for side in ("baseline", "candidate"):
+        if side not in redacted:
+            continue
+        if sensitive_path:
+            redacted[side] = policy.replacement
+        else:
+            redacted[side] = policy.redact(redacted[side])
+    return redacted
+
+
+def _json_compatible_scalar(value: Any) -> Any:
+    """Return a scalar that the CLI JSON renderer can serialize."""
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float):
+        return value if math.isfinite(value) else str(value)
+    if hasattr(value, "to_dict") and callable(value.to_dict):
+        try:
+            return _ReportNormalizer(RunReportDiffConfig()).normalize(value.to_dict())
+        except (TypeError, ValueError):
+            return str(value)
+    try:
+        json.dumps(value, allow_nan=False)
+        return value
+    except (TypeError, ValueError):
+        return str(value)
+
+
+def _preview(value: Any, *, max_length: int = 180) -> str:
+    rendered = _canonical_json(value)
+    if len(rendered) <= max_length:
+        return rendered
+    return rendered[: max_length - 3] + "..."
+
+
+def _canonical_json(value: Any) -> str:
+    try:
+        return json.dumps(
+            value,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+            default=str,
+        )
+    except (TypeError, ValueError):
+        return repr(value)
+
+
+def _json_pointer(path: tuple[str, ...]) -> str:
+    if not path:
+        return ""
+    return "/" + "/".join(segment.replace("~", "~0").replace("/", "~1") for segment in path)
+
+
+def _parse_pointer_pattern(pattern: str) -> tuple[str, ...]:
+    if not isinstance(pattern, str) or not pattern.startswith("/") or pattern == "/":
+        raise ValueError("Path patterns must be non-root RFC 6901 JSON Pointers")
+    raw_segments = pattern[1:].split("/")
+    for segment in raw_segments:
+        index = 0
+        while index < len(segment):
+            if segment[index] != "~":
+                index += 1
+                continue
+            if index + 1 >= len(segment) or segment[index + 1] not in {"0", "1"}:
+                raise ValueError(f"Invalid RFC 6901 escape in path pattern: {pattern!r}")
+            index += 2
+    return tuple(segment.replace("~1", "/").replace("~0", "~") for segment in raw_segments)
+
+
+def _pattern_matches_exact(pattern: tuple[str, ...], path: tuple[str, ...]) -> bool:
+    return len(pattern) == len(path) and all(
+        expected == "*" or expected == actual for expected, actual in zip(pattern, path, strict=True)
+    )
+
+
+def _pattern_matches_prefix(pattern: tuple[str, ...], path: tuple[str, ...]) -> bool:
+    if len(pattern) > len(path):
+        return False
+    return all(expected == "*" or expected == actual for expected, actual in zip(pattern, path, strict=False))
+
+
+_IDENTIFIER_PATHS: tuple[tuple[str, tuple[str, ...]], ...] = tuple(
+    (category, _parse_pointer_pattern(pattern))
+    for category, pattern in (
+        ("run", "/context/run_id"),
+        ("session", "/context/session_id"),
+        ("trace", "/context/trace_id"),
+        ("run", "/context/parent_run_id"),
+        ("run", "/context_manifests/*/run_id"),
+        ("session", "/context_manifests/*/session_id"),
+        ("event", "/events/*/event_id"),
+        ("run", "/events/*/run_id"),
+        ("task", "/events/*/task_id"),
+        ("span", "/events/*/span_id"),
+        ("span", "/events/*/parent_span_id"),
+        ("action", "/events/*/action_id"),
+        ("action", "/events/*/parent_action_id"),
+        ("delegation", "/events/*/delegation_id"),
+        ("event", "/events/*/payload/event_id"),
+        ("run", "/events/*/payload/run_id"),
+        ("task", "/events/*/payload/task_id"),
+        ("span", "/events/*/payload/span_id"),
+        ("span", "/events/*/payload/parent_span_id"),
+        ("action", "/events/*/payload/action_id"),
+        ("action", "/events/*/payload/parent_action_id"),
+        ("delegation", "/events/*/payload/delegation_id"),
+        ("approval", "/events/*/payload/request_id"),
+        ("run", "/events/*/payload/manifest/run_id"),
+        ("session", "/events/*/payload/manifest/session_id"),
+        ("run", "/events/*/payload/metadata/manifest/run_id"),
+        ("session", "/events/*/payload/metadata/manifest/session_id"),
+        ("run", "/events/*/payload/metadata/run_id"),
+        ("session", "/events/*/payload/metadata/session_id"),
+        ("trace", "/events/*/payload/metadata/trace_id"),
+        ("run", "/events/*/payload/metadata/run_context/run_id"),
+        ("session", "/events/*/payload/metadata/run_context/session_id"),
+        ("trace", "/events/*/payload/metadata/run_context/trace_id"),
+        ("run", "/events/*/payload/metadata/run_context/parent_run_id"),
+        ("task", "/events/*/payload/metadata/task/id"),
+        ("message", "/events/*/payload/metadata/task/messages/*/id"),
+        ("artifact", "/events/*/payload/metadata/task/artifacts/*/id"),
+        ("action", "/events/*/payload/metadata/task/artifacts/*/action_id"),
+        ("run", "/events/*/payload/metadata/task/metadata/run_id"),
+        ("session", "/events/*/payload/metadata/task/metadata/session_id"),
+        ("trace", "/events/*/payload/metadata/task/metadata/trace_id"),
+        ("run", "/events/*/payload/metadata/task/metadata/parent_run_id"),
+        ("run", "/events/*/payload/metadata/task/metadata/run_context/run_id"),
+        ("session", "/events/*/payload/metadata/task/metadata/run_context/session_id"),
+        ("trace", "/events/*/payload/metadata/task/metadata/run_context/trace_id"),
+        ("run", "/events/*/payload/metadata/task/metadata/run_context/parent_run_id"),
+        ("action", "/events/*/payload/action/action_id"),
+        ("artifact", "/events/*/payload/action/artifacts/*/id"),
+        ("action", "/events/*/payload/action/artifacts/*/action_id"),
+        ("approval", "/events/*/payload/request/request_id"),
+        ("run", "/events/*/payload/request/run_id"),
+        ("action", "/events/*/payload/request/action/action_id"),
+        ("artifact", "/events/*/payload/request/action/artifacts/*/id"),
+        ("action", "/events/*/payload/request/action/artifacts/*/action_id"),
+        ("approval", "/events/*/payload/decision/request_id"),
+        ("artifact", "/events/*/payload/artifact/id"),
+        ("action", "/events/*/payload/artifact/action_id"),
+        ("action", "/actions/*/action_id"),
+        ("artifact", "/actions/*/artifacts/*/id"),
+        ("action", "/actions/*/artifacts/*/action_id"),
+        ("approval", "/approvals/*/request/request_id"),
+        ("run", "/approvals/*/request/run_id"),
+        ("action", "/approvals/*/request/action/action_id"),
+        ("artifact", "/approvals/*/request/action/artifacts/*/id"),
+        ("action", "/approvals/*/request/action/artifacts/*/action_id"),
+        ("approval", "/approvals/*/decision/request_id"),
+        ("artifact", "/artifacts/*/id"),
+        ("action", "/artifacts/*/action_id"),
+        ("run", "/metrics/*/run_id"),
+        ("session", "/metrics/*/session_id"),
+        ("trace", "/metrics/*/trace_id"),
+        ("task", "/final_task/id"),
+        ("message", "/final_task/messages/*/id"),
+        ("artifact", "/final_task/artifacts/*/id"),
+        ("action", "/final_task/artifacts/*/action_id"),
+        ("run", "/final_task/metadata/run_id"),
+        ("session", "/final_task/metadata/session_id"),
+        ("trace", "/final_task/metadata/trace_id"),
+        ("run", "/final_task/metadata/parent_run_id"),
+        ("run", "/final_task/metadata/run_context/run_id"),
+        ("session", "/final_task/metadata/run_context/session_id"),
+        ("trace", "/final_task/metadata/run_context/trace_id"),
+        ("run", "/final_task/metadata/run_context/parent_run_id"),
+    )
+)
+
+_VOLATILE_SCALAR_PATHS: tuple[tuple[str, tuple[str, ...]], ...] = tuple(
+    (label, _parse_pointer_pattern(pattern))
+    for label, pattern in (
+        ("timestamp", "/context/created_at"),
+        ("timestamp", "/context_manifests/*/created_at"),
+        ("timestamp", "/events/*/timestamp"),
+        ("sequence", "/events/*/sequence"),
+        ("timestamp", "/events/*/payload/timestamp"),
+        ("timestamp", "/events/*/payload/created_at"),
+        ("timestamp", "/events/*/payload/updated_at"),
+        ("timestamp", "/events/*/payload/manifest/created_at"),
+        ("timestamp", "/events/*/payload/metadata/manifest/created_at"),
+        ("timestamp", "/events/*/payload/metadata/run_context/created_at"),
+        ("timestamp", "/events/*/payload/metadata/task/created_at"),
+        ("timestamp", "/events/*/payload/metadata/task/messages/*/timestamp"),
+        ("timestamp", "/events/*/payload/metadata/task/artifacts/*/timestamp"),
+        ("timestamp", "/events/*/payload/metadata/task/metadata/state_history/*/timestamp"),
+        ("timestamp", "/events/*/payload/metadata/task/metadata/run_context/created_at"),
+        ("timestamp", "/events/*/payload/action/created_at"),
+        ("timestamp", "/events/*/payload/action/artifacts/*/timestamp"),
+        ("timestamp", "/events/*/payload/request/created_at"),
+        ("timestamp", "/events/*/payload/request/action/created_at"),
+        ("timestamp", "/events/*/payload/request/action/artifacts/*/timestamp"),
+        ("timestamp", "/events/*/payload/decision/decided_at"),
+        ("timestamp", "/events/*/payload/artifact/timestamp"),
+        ("timestamp", "/actions/*/created_at"),
+        ("timestamp", "/actions/*/artifacts/*/timestamp"),
+        ("timestamp", "/approvals/*/request/created_at"),
+        ("timestamp", "/approvals/*/request/action/created_at"),
+        ("timestamp", "/approvals/*/request/action/artifacts/*/timestamp"),
+        ("timestamp", "/approvals/*/decision/decided_at"),
+        ("timestamp", "/artifacts/*/timestamp"),
+        ("timestamp", "/final_task/created_at"),
+        ("timestamp", "/final_task/messages/*/timestamp"),
+        ("timestamp", "/final_task/artifacts/*/timestamp"),
+        ("timestamp", "/final_task/metadata/state_history/*/timestamp"),
+        ("timestamp", "/final_task/metadata/run_context/created_at"),
+    )
+)
+
+
+def _volatile_identifier_category(
+    path: tuple[str, ...],
+    *,
+    runtime_event: bool,
+) -> str | None:
+    if not runtime_event and _is_event_payload_path(path):
+        return None
+    for category, pattern in _IDENTIFIER_PATHS:
+        if _pattern_matches_exact(pattern, path):
+            return category
+    return None
+
+
+def _is_volatile_scalar(
+    path: tuple[str, ...],
+    *,
+    runtime_event: bool,
+) -> bool:
+    if not runtime_event and _is_event_payload_path(path):
+        return False
+    if _is_runtime_summary_path(path):
+        return runtime_event
+    if _is_runtime_duration_path(path):
+        return path[0] == "metrics" or runtime_event
+    return any(_pattern_matches_exact(pattern, path) for _, pattern in _VOLATILE_SCALAR_PATHS)
+
+
+def _volatile_scalar_label(
+    path: tuple[str, ...],
+    *,
+    runtime_event: bool,
+) -> str:
+    if _is_runtime_summary_path(path) and runtime_event:
+        return "summary"
+    if _is_runtime_duration_path(path) and (path[0] == "metrics" or runtime_event):
+        return "duration"
+    for label, pattern in _VOLATILE_SCALAR_PATHS:
+        if _pattern_matches_exact(pattern, path):
+            return label
+    return "volatile"
+
+
+def _is_runtime_event_mapping(value: Mapping[str, Any]) -> bool:
+    """Return whether an event was normalized from a task-stream envelope."""
+    metadata = value.get("metadata")
+    return isinstance(metadata, Mapping) and bool(metadata.get("source_type"))
+
+
+def _is_event_payload_path(path: tuple[str, ...]) -> bool:
+    return len(path) >= 3 and path[0] == "events" and path[2] == "payload"
+
+
+def _identifier_namespace(category: str) -> str:
+    if category in {"action", "delegation", "span"}:
+        # Runtime agent calls intentionally reuse one correlation value across
+        # these fields, so their equality belongs to one namespace.
+        return "correlation"
+    return category
+
+
+def _is_runtime_summary_path(path: tuple[str, ...]) -> bool:
+    return len(path) == 3 and path[0] == "events" and path[2] == "summary"
+
+
+def _is_runtime_duration_path(path: tuple[str, ...]) -> bool:
+    if not path or path[-1] not in {"latency_ms", "runtime_seconds"}:
+        return False
+    if path[0] == "metrics":
+        return True
+    return len(path) >= 5 and path[0] == "events" and path[2] == "payload" and path[3] == "metadata"

--- a/protolink/devtools/__init__.py
+++ b/protolink/devtools/__init__.py
@@ -8,16 +8,18 @@ collectors and renderers in their own CLIs or notebooks.
 
 from .agents import chat_with_agent, ping_agent
 from .doctor import build_doctor_report
-from .models import CheckResult, DoctorReport, RunReplayItem, RunReplayView
+from .models import CheckResult, DoctorReport, RunDiffView, RunReplayItem, RunReplayView
 from .registry import fetch_registry_agents, inspect_registry_agent
-from .runs import build_run_replay_view, list_run_store_records
+from .runs import build_run_diff_view, build_run_replay_view, list_run_store_records
 
 __all__ = [
     "CheckResult",
     "DoctorReport",
+    "RunDiffView",
     "RunReplayItem",
     "RunReplayView",
     "build_doctor_report",
+    "build_run_diff_view",
     "build_run_replay_view",
     "chat_with_agent",
     "fetch_registry_agents",

--- a/protolink/devtools/models.py
+++ b/protolink/devtools/models.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
+from protolink.core.redaction import DEFAULT_REDACTION_POLICY, RedactionPolicy
+from protolink.core.report_diff import RunReportDiff
+
 CheckStatus = Literal["ok", "warn", "error"]
 """Status values emitted by devtool health checks."""
 
@@ -100,3 +103,52 @@ class RunReplayView:
             "source": self.source,
             "items": [item.to_dict() for item in self.items],
         }
+
+
+@dataclass(frozen=True)
+class RunDiffView:
+    """Human-facing comparison of two stored run reports.
+
+    ``RunDiffView`` keeps store lookup state separate from the core diff
+    contract. A missing report is therefore distinguishable from a valid
+    comparison that found behavioral differences.
+    """
+
+    baseline_run_id: str
+    candidate_run_id: str
+    diff: RunReportDiff | None = None
+    missing_run_ids: tuple[str, ...] = ()
+
+    @property
+    def status(self) -> Literal["match", "changed", "missing"]:
+        """Return the comparison outcome."""
+        if self.missing_run_ids or self.diff is None:
+            return "missing"
+        return "match" if self.diff.matches else "changed"
+
+    def to_dict(
+        self,
+        *,
+        redaction_policy: RedactionPolicy | None = DEFAULT_REDACTION_POLICY,
+    ) -> dict[str, Any]:
+        """Serialize this comparison, masking diff secrets by default."""
+        payload: dict[str, Any] = {
+            "baseline_run_id": self.baseline_run_id,
+            "candidate_run_id": self.candidate_run_id,
+            "status": self.status,
+            "missing_run_ids": list(self.missing_run_ids),
+        }
+        if self.diff is None:
+            payload.update(
+                {
+                    "matches": None,
+                    "difference_count": 0,
+                    "changed_sections": [],
+                    "compared_sections": [],
+                    "ignored_paths": [],
+                    "differences": [],
+                }
+            )
+        else:
+            payload.update(self.diff.to_dict(redaction_policy=redaction_policy))
+        return payload

--- a/protolink/devtools/runs.py
+++ b/protolink/devtools/runs.py
@@ -6,7 +6,8 @@ from pathlib import Path
 from typing import Any
 
 from protolink.core.report import RunReplay
-from protolink.devtools.models import RunReplayItem, RunReplayView
+from protolink.core.report_diff import RunReportDiffConfig, diff_run_reports
+from protolink.devtools.models import RunDiffView, RunReplayItem, RunReplayView
 from protolink.storage import SQLiteRunStore
 
 
@@ -67,6 +68,48 @@ def build_run_replay_view(store_path: str | Path, run_id: str) -> RunReplayView:
         final_task=task_record.task,
         items=(item,),
         source="task",
+    )
+
+
+def build_run_diff_view(
+    store_path: str | Path,
+    baseline_run_id: str,
+    candidate_run_id: str,
+    *,
+    config: RunReportDiffConfig | None = None,
+) -> RunDiffView:
+    """Compare two stored run reports after applying diff normalization.
+
+    Unlike replay, report diffing never falls back to task snapshots. A task
+    snapshot does not contain the event, action, approval, metric, or context
+    sections needed for a meaningful behavioral comparison.
+    """
+    store = SQLiteRunStore(store_path)
+    baseline = store.get_report(baseline_run_id)
+    candidate = store.get_report(candidate_run_id)
+    missing_run_ids = tuple(
+        dict.fromkeys(
+            run_id
+            for run_id, report in (
+                (baseline_run_id, baseline),
+                (candidate_run_id, candidate),
+            )
+            if report is None
+        )
+    )
+    if missing_run_ids:
+        return RunDiffView(
+            baseline_run_id=baseline_run_id,
+            candidate_run_id=candidate_run_id,
+            missing_run_ids=missing_run_ids,
+        )
+
+    if baseline is None or candidate is None:  # pragma: no cover - narrowed above
+        raise RuntimeError("Stored run-report lookup produced an inconsistent result")
+    return RunDiffView(
+        baseline_run_id=baseline_run_id,
+        candidate_run_id=candidate_run_id,
+        diff=diff_run_reports(baseline, candidate, config=config),
     )
 
 

--- a/protolink/models/__init__.py
+++ b/protolink/models/__init__.py
@@ -9,6 +9,15 @@ from protolink.core.events import EventSink, InMemoryEventSink, RunEvent
 from protolink.core.message import Message
 from protolink.core.part import Part, RouteDecision
 from protolink.core.report import RunRecorder, RunReplay, RunReport
+from protolink.core.report_diff import (
+    RunReportDiff,
+    RunReportDiffConfig,
+    RunReportDifference,
+    RunReportDifferenceKind,
+    RunReportSection,
+    RunReportSource,
+    RunReportTolerance,
+)
 from protolink.core.run_context import RunBudget, RunContext
 from protolink.core.task import Task, TaskState
 from protolink.llms.compaction import HistoryCompactionRequest, HistoryCompactionResult
@@ -36,6 +45,13 @@ __all__ = [
     "RunRecorder",
     "RunReplay",
     "RunReport",
+    "RunReportDiff",
+    "RunReportDiffConfig",
+    "RunReportDifference",
+    "RunReportDifferenceKind",
+    "RunReportSection",
+    "RunReportSource",
+    "RunReportTolerance",
     "StateOperationRequest",
     "StateOperationResult",
     "StateStoreReport",

--- a/protolink/utils/renderers/devtools.py
+++ b/protolink/utils/renderers/devtools.py
@@ -8,7 +8,7 @@ from collections.abc import Sequence
 from html import escape
 from typing import Any
 
-from protolink.devtools.models import DoctorReport, RunReplayView
+from protolink.devtools.models import DoctorReport, RunDiffView, RunReplayView
 
 
 class DevtoolsTextRenderer:
@@ -78,6 +78,22 @@ class DevtoolsTextRenderer:
             for item in view.items
         ]
         return header + "\n" + _table(("TIME", "EVENT", "LEVEL", "AGENT", "SUMMARY"), rows)
+
+    def render_run_diff(self, view: RunDiffView) -> str:
+        """Render a normalized comparison of two stored run reports."""
+        if view.status == "missing":
+            label = "Run report not found" if len(view.missing_run_ids) == 1 else "Run reports not found"
+            return f"{label}: {', '.join(view.missing_run_ids)}"
+
+        header = f"Normalized run report diff: {view.baseline_run_id} -> {view.candidate_run_id}"
+        if view.diff is None:  # pragma: no cover - guarded by status
+            return header + "\nResult: MISSING"
+        if view.diff.matches:
+            return header + "\nResult: MATCH\nNo behavioral differences after normalization."
+
+        count = len(view.diff.differences)
+        label = "difference" if count == 1 else "differences"
+        return header + f"\nResult: CHANGED ({count} {label})\n" + view.diff.format(max_differences=50)
 
 
 class DevtoolsHtmlRenderer:

--- a/tests/test_devtools_cli.py
+++ b/tests/test_devtools_cli.py
@@ -5,7 +5,13 @@ import pytest
 
 from protolink import RunContext, RunEvent, RunReport, SQLiteRunStore, Task
 from protolink.cli import main as cli_main
-from protolink.devtools import build_run_replay_view, chat_with_agent, list_run_store_records, ping_agent
+from protolink.devtools import (
+    build_run_diff_view,
+    build_run_replay_view,
+    chat_with_agent,
+    list_run_store_records,
+    ping_agent,
+)
 from protolink.devtools.server import build_dashboard_snapshot
 from protolink.utils.renderers.devtools import DevtoolsHtmlRenderer
 
@@ -34,6 +40,127 @@ def test_cli_run_list_and_replay_use_sqlite_run_store(tmp_path: Path, capsys):
 
     assert "Run replay: run_cli" in output
     assert "llm.call.completed" in output
+
+
+def test_cli_run_diff_matches_after_volatile_normalization(tmp_path: Path, capsys):
+    store_path = tmp_path / "runs.db"
+    _seed_run_store(store_path)
+    _seed_candidate_report(store_path, run_id="run_cli_match", model="mock")
+
+    args = ["run", "diff", "run_cli", "run_cli_match", "--store", str(store_path)]
+    assert cli_main(args) == 0
+    output = capsys.readouterr().out
+
+    assert "Normalized run report diff: run_cli -> run_cli_match" in output
+    assert "Result: MATCH" in output
+
+    assert cli_main([*args, "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["baseline_run_id"] == "run_cli"
+    assert payload["candidate_run_id"] == "run_cli_match"
+    assert payload["status"] == "match"
+    assert payload["matches"] is True
+    assert payload["changed_sections"] == []
+    assert payload["differences"] == []
+
+
+def test_cli_run_diff_emits_text_and_json_for_behavior_changes(tmp_path: Path, capsys):
+    store_path = tmp_path / "runs.db"
+    _seed_run_store(store_path)
+    _seed_candidate_report(store_path, run_id="run_cli_changed", model="mock-v2")
+
+    args = ["run", "diff", "run_cli", "run_cli_changed", "--store", str(store_path)]
+    assert cli_main(args) == 1
+    output = capsys.readouterr().out
+
+    assert "Normalized run report diff: run_cli -> run_cli_changed" in output
+    assert "Result: CHANGED" in output
+    assert "events" in output
+
+    assert cli_main([*args, "--json"]) == 1
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["status"] == "changed"
+    assert payload["matches"] is False
+    assert "events" in payload["changed_sections"]
+    assert any(
+        difference.get("baseline") == "mock" and difference.get("candidate") == "mock-v2"
+        for difference in payload["differences"]
+    )
+
+
+def test_cli_run_diff_requires_two_reports_without_task_fallback(tmp_path: Path, capsys):
+    store_path = tmp_path / "runs.db"
+    _seed_run_store(store_path)
+    store = SQLiteRunStore(store_path)
+    task = Task.create_infer(prompt="task snapshots are not reports")
+    context = RunContext(run_id="run_task_only")
+    context.attach_to_task(task)
+    task.complete("done")
+    store.save_task(task, context=context, agent_name="cli_agent")
+
+    view = build_run_diff_view(store_path, "run_cli", "run_task_only")
+    assert view.status == "missing"
+    assert view.missing_run_ids == ("run_task_only",)
+
+    args = ["run", "diff", "run_cli", "run_task_only", "--store", str(store_path)]
+    assert cli_main(args) == 2
+    assert capsys.readouterr().out.strip() == "Run report not found: run_task_only"
+
+    assert cli_main([*args, "--json"]) == 2
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload == {
+        "baseline_run_id": "run_cli",
+        "candidate_run_id": "run_task_only",
+        "status": "missing",
+        "missing_run_ids": ["run_task_only"],
+        "matches": None,
+        "difference_count": 0,
+        "changed_sections": [],
+        "compared_sections": [],
+        "ignored_paths": [],
+        "differences": [],
+    }
+
+
+def test_cli_run_diff_json_redacts_secret_values(tmp_path: Path, capsys):
+    store_path = tmp_path / "runs.db"
+    store = SQLiteRunStore(store_path)
+    for run_id, secret in (
+        ("run_secret_baseline", "baseline-secret"),
+        ("run_secret_candidate", "candidate-secret"),
+    ):
+        context = RunContext(run_id=run_id)
+        report = RunReport.from_events(
+            [],
+            context=context,
+            metadata={"credentials": {"client_id": secret}},
+        )
+        store.save_report(report)
+
+    assert (
+        cli_main(
+            [
+                "run",
+                "diff",
+                "run_secret_baseline",
+                "run_secret_candidate",
+                "--store",
+                str(store_path),
+                "--json",
+            ]
+        )
+        == 1
+    )
+    payload = json.loads(capsys.readouterr().out)
+    difference = payload["differences"][0]
+
+    assert difference["baseline"] == "[REDACTED]"
+    assert difference["candidate"] == "[REDACTED]"
+    assert "baseline-secret" not in json.dumps(payload)
+    assert "candidate-secret" not in json.dumps(payload)
 
 
 def test_devtools_helpers_project_store_records(tmp_path: Path):
@@ -192,3 +319,37 @@ def _seed_run_store(store_path: Path) -> str:
     )
     store.save_report(report, agent_name="cli_agent")
     return task.id
+
+
+def _seed_candidate_report(store_path: Path, *, run_id: str, model: str) -> None:
+    store = SQLiteRunStore(store_path)
+    task = Task.create_infer(prompt="hello")
+    context = RunContext(
+        run_id=run_id,
+        session_id="session_cli",
+        trace_id="trace_cli",
+        agent_chain=["client"],
+    )
+    context.attach_to_task(task)
+    task.complete("done")
+    report = RunReport.from_events(
+        [
+            RunEvent(
+                type="task.status",
+                run_id=context.run_id,
+                task_id=task.id,
+                agent_name="cli_agent",
+                payload={"previous_state": "working", "new_state": "completed"},
+            ),
+            RunEvent(
+                type="llm.call.completed",
+                run_id=context.run_id,
+                task_id=task.id,
+                agent_name="cli_agent",
+                payload={"provider": "mock", "model": model},
+            ),
+        ],
+        context=context,
+        final_task=task.to_dict(),
+    )
+    store.save_report(report, agent_name="cli_agent")

--- a/tests/test_run_report_diff.py
+++ b/tests/test_run_report_diff.py
@@ -1,0 +1,771 @@
+"""Normalized run-report regression comparison tests."""
+
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+from protolink import (
+    Agent,
+    AgentCard,
+    RedactionPolicy,
+    RunContext,
+    RunRecorder,
+    RunReplay,
+    RunReport,
+    RunReportDiffConfig,
+    RunReportTolerance,
+    Task,
+    assert_run_matches,
+    create_llm,
+    diff_run_reports,
+    normalize_run_report,
+)
+
+
+def test_fresh_runtime_identifiers_and_timestamps_normalize_without_hiding_business_values() -> None:
+    baseline = _report_payload(
+        run_id="run_baseline",
+        task_id="task_baseline",
+        event_id="event_baseline",
+        message_id="message_baseline",
+        timestamp="2026-07-17T08:00:00Z",
+        business_id="order-42",
+        business_timestamp="2030-01-01T00:00:00Z",
+    )
+    candidate = _report_payload(
+        run_id="run_candidate",
+        task_id="task_candidate",
+        event_id="event_candidate",
+        message_id="message_candidate",
+        timestamp="2026-07-17T09:00:00Z",
+        business_id="order-42",
+        business_timestamp="2030-01-01T00:00:00Z",
+    )
+
+    comparison = diff_run_reports(baseline, candidate)
+
+    assert comparison.matches
+    assert comparison.differences == ()
+
+    candidate["events"][0]["payload"]["result"]["id"] = "order-99"
+    business_id_diff = diff_run_reports(baseline, candidate)
+    assert not business_id_diff.matches
+    assert any(difference.path == "/events/0/payload/result/id" for difference in business_id_diff.differences)
+
+    candidate["events"][0]["payload"]["result"]["id"] = "order-42"
+    candidate["events"][0]["payload"]["result"]["timestamp"] = "2031-01-01T00:00:00Z"
+    business_time_diff = diff_run_reports(baseline, candidate)
+    assert any(difference.path == "/events/0/payload/result/timestamp" for difference in business_time_diff.differences)
+
+
+def test_identifier_canonicalization_preserves_runtime_relationships() -> None:
+    baseline = _report_payload(run_id="run_a", task_id="task_a", event_id="event_a")
+    candidate = _report_payload(run_id="run_b", task_id="task_b", event_id="event_b")
+
+    assert diff_run_reports(baseline, candidate).matches
+
+    candidate["events"][0]["run_id"] = "different_candidate_run"
+    result = diff_run_reports(baseline, candidate)
+
+    assert not result.matches
+    assert any(difference.path == "/events/0/run_id" for difference in result.differences)
+
+
+def test_action_and_span_correlation_relationship_changes_are_detected() -> None:
+    baseline = RunReport.from_dict(
+        {
+            "events": [
+                {
+                    "type": "action.completed",
+                    "action_id": "shared-correlation",
+                    "span_id": "shared-correlation",
+                }
+            ]
+        }
+    )
+    candidate = RunReport.from_dict(
+        {
+            "events": [
+                {
+                    "type": "action.completed",
+                    "action_id": "candidate-action",
+                    "span_id": "candidate-span",
+                }
+            ]
+        }
+    )
+
+    result = diff_run_reports(
+        baseline,
+        candidate,
+        config=RunReportDiffConfig(sections=("events",)),
+    )
+
+    assert not result.matches
+    assert any(difference.path in {"/events/0/action_id", "/events/0/span_id"} for difference in result.differences)
+
+
+def test_task_and_final_task_identifier_relationship_changes_are_detected() -> None:
+    baseline = {
+        "events": [{"type": "task.status", "task_id": "baseline-task"}],
+        "final_task": {"id": "baseline-task"},
+    }
+    candidate = {
+        "events": [{"type": "task.status", "task_id": "wrong-event-task"}],
+        "final_task": {"id": "candidate-task"},
+    }
+
+    result = diff_run_reports(baseline, candidate)
+
+    assert not result.matches
+    assert {difference.path for difference in result.differences} == {
+        "/events/0/task_id",
+        "/final_task/id",
+    }
+
+
+def test_approval_request_and_decision_identifier_relationship_changes_are_detected() -> None:
+    baseline = {
+        "approvals": [
+            {
+                "type": "approval.decided",
+                "request": {"request_id": "baseline-request"},
+                "decision": {"request_id": "baseline-request"},
+            }
+        ]
+    }
+    candidate = {
+        "approvals": [
+            {
+                "type": "approval.decided",
+                "request": {"request_id": "candidate-request"},
+                "decision": {"request_id": "wrong-decision-request"},
+            }
+        ]
+    }
+
+    result = diff_run_reports(
+        baseline,
+        candidate,
+        config=RunReportDiffConfig(sections=("approvals",)),
+    )
+
+    assert not result.matches
+    assert {difference.path for difference in result.differences} == {
+        "/approvals/0/decision/request_id",
+        "/approvals/0/request/request_id",
+    }
+
+
+def test_action_span_and_delegation_share_one_correlation_namespace() -> None:
+    baseline = {
+        "events": [
+            {
+                "type": "action.completed",
+                "action_id": "baseline-correlation",
+                "span_id": "baseline-correlation",
+                "delegation_id": "baseline-correlation",
+            }
+        ]
+    }
+    candidate = {
+        "events": [
+            {
+                "type": "action.completed",
+                "action_id": "candidate-correlation",
+                "span_id": "candidate-correlation",
+                "delegation_id": "wrong-delegation",
+            }
+        ]
+    }
+
+    result = diff_run_reports(
+        baseline,
+        candidate,
+        config=RunReportDiffConfig(sections=("events",)),
+    )
+
+    assert [difference.path for difference in result.differences] == ["/events/0/delegation_id"]
+
+
+def test_session_artifact_and_message_relationship_changes_are_detected() -> None:
+    baseline = {
+        "context": {"run_id": "run-a", "session_id": "session-a"},
+        "context_manifests": [{"session_id": "session-a"}],
+        "events": [
+            {
+                "type": "task.status",
+                "metadata": {"source_type": "task_status_update"},
+                "payload": {
+                    "metadata": {
+                        "task": {
+                            "messages": [{"id": "message-a"}],
+                        }
+                    }
+                },
+            }
+        ],
+        "artifacts": [{"id": "artifact-a"}],
+        "final_task": {
+            "messages": [{"id": "message-a"}],
+            "artifacts": [{"id": "artifact-a"}],
+        },
+    }
+    candidate = copy.deepcopy(baseline)
+    candidate["context"]["session_id"] = "session-b"
+    candidate["context_manifests"][0]["session_id"] = "wrong-manifest-session"
+    candidate["events"][0]["payload"]["metadata"]["task"]["messages"][0]["id"] = "wrong-event-message"
+    candidate["artifacts"][0]["id"] = "artifact-b"
+    candidate["final_task"]["messages"][0]["id"] = "message-b"
+    candidate["final_task"]["artifacts"][0]["id"] = "wrong-final-artifact"
+
+    result = diff_run_reports(baseline, candidate)
+
+    assert not result.matches
+    changed_paths = {difference.path for difference in result.differences}
+    assert "/context/session_id" in changed_paths
+    assert "/context_manifests/0/session_id" in changed_paths
+    assert "/events/0/payload/metadata/task/messages/0/id" in changed_paths
+    assert "/artifacts/0/id" in changed_paths
+    assert "/final_task/messages/0/id" in changed_paths
+    assert "/final_task/artifacts/0/id" in changed_paths
+
+
+@pytest.mark.asyncio
+async def test_separately_recorded_equivalent_mock_agent_runs_match() -> None:
+    baseline = await _record_mock_run("run_baseline")
+    candidate = await _record_mock_run("run_candidate")
+
+    result = diff_run_reports(baseline, candidate)
+
+    assert result.matches, result.format(max_differences=100, redaction_policy=None)
+
+
+def test_custom_event_payload_identifiers_and_timestamps_remain_behavioral() -> None:
+    baseline = RunReport.from_dict(
+        {
+            "events": [
+                {
+                    "type": "application.checkpoint",
+                    "payload": {
+                        "task_id": "business-task-a",
+                        "timestamp": "2030-01-01T00:00:00Z",
+                    },
+                }
+            ]
+        }
+    )
+    candidate = RunReport.from_dict(
+        {
+            "events": [
+                {
+                    "type": "application.checkpoint",
+                    "payload": {
+                        "task_id": "business-task-b",
+                        "timestamp": "2031-01-01T00:00:00Z",
+                    },
+                }
+            ]
+        }
+    )
+
+    result = diff_run_reports(
+        baseline,
+        candidate,
+        config=RunReportDiffConfig(sections=("events",)),
+    )
+
+    assert {difference.path for difference in result.differences} == {
+        "/events/0/payload/task_id",
+        "/events/0/payload/timestamp",
+    }
+
+
+def test_nested_custom_event_payload_runtime_shaped_values_remain_behavioral() -> None:
+    baseline = {
+        "events": [
+            {
+                "type": "application.audit",
+                "payload": {
+                    "request": {"run_id": "order-a"},
+                    "action": {"created_at": "2030-01-01T00:00:00Z"},
+                    "artifact": {"id": "invoice-a"},
+                },
+            }
+        ]
+    }
+    candidate = copy.deepcopy(baseline)
+    candidate["events"][0]["payload"]["request"]["run_id"] = "order-b"
+    candidate["events"][0]["payload"]["action"]["created_at"] = "2031-01-01T00:00:00Z"
+    candidate["events"][0]["payload"]["artifact"]["id"] = "invoice-b"
+
+    result = diff_run_reports(
+        baseline,
+        candidate,
+        config=RunReportDiffConfig(sections=("events",)),
+    )
+
+    assert {difference.path for difference in result.differences} == {
+        "/events/0/payload/action/created_at",
+        "/events/0/payload/artifact/id",
+        "/events/0/payload/request/run_id",
+    }
+
+
+def test_inserted_event_is_aligned_without_cascading_later_events() -> None:
+    baseline = RunReport.from_dict(
+        {
+            "events": [
+                {"type": "llm.call.started", "payload": {"model": "mock"}},
+                {"type": "llm.call.completed", "payload": {"model": "mock", "result": "done"}},
+            ]
+        }
+    )
+    candidate = RunReport.from_dict(
+        {
+            "events": [
+                {"type": "llm.call.started", "payload": {"model": "mock"}},
+                {"type": "task.progress", "payload": {"percent": 50}},
+                {"type": "llm.call.completed", "payload": {"model": "mock", "result": "done"}},
+            ]
+        }
+    )
+
+    result = diff_run_reports(
+        baseline,
+        candidate,
+        config=RunReportDiffConfig(sections=("events",)),
+    )
+
+    assert len(result.differences) == 1
+    assert result.differences[0].kind == "added"
+    assert result.differences[0].path == "/events/1"
+
+
+def test_inserted_repeated_event_and_new_task_id_do_not_shift_later_items() -> None:
+    baseline = RunReport.from_dict(
+        {
+            "events": [
+                {
+                    "type": "task.status",
+                    "task_id": "task-a",
+                    "payload": {"state": "working"},
+                },
+                {
+                    "type": "task.status",
+                    "task_id": "task-a",
+                    "payload": {"state": "completed"},
+                },
+            ]
+        }
+    )
+    candidate = RunReport.from_dict(
+        {
+            "events": [
+                {
+                    "type": "task.status",
+                    "task_id": "inserted-task",
+                    "payload": {"state": "submitted"},
+                },
+                {
+                    "type": "task.status",
+                    "task_id": "candidate-task",
+                    "payload": {"state": "working"},
+                },
+                {
+                    "type": "task.status",
+                    "task_id": "candidate-task",
+                    "payload": {"state": "completed"},
+                },
+            ]
+        }
+    )
+
+    result = diff_run_reports(
+        baseline,
+        candidate,
+        config=RunReportDiffConfig(sections=("events",)),
+    )
+
+    assert len(result.differences) == 1
+    assert result.differences[0].kind == "added"
+    assert result.differences[0].path == "/events/0"
+
+
+def test_changed_event_payload_has_a_precise_json_pointer_path() -> None:
+    baseline = RunReport.from_dict({"events": [{"type": "llm.call.completed", "payload": {"model": "mock-v1"}}]})
+    candidate = RunReport.from_dict({"events": [{"type": "llm.call.completed", "payload": {"model": "mock-v2"}}]})
+
+    result = diff_run_reports(
+        baseline,
+        candidate,
+        config=RunReportDiffConfig(sections=("events",)),
+    )
+
+    assert [difference.path for difference in result.differences] == ["/events/0/payload/model"]
+    assert result.differences[0].baseline == "mock-v1"
+    assert result.differences[0].candidate == "mock-v2"
+
+
+def test_final_task_action_approval_and_artifact_changes_are_compared() -> None:
+    baseline = RunReport.from_dict(
+        {
+            "actions": [
+                {
+                    "action_id": "action_a",
+                    "kind": "tool.call",
+                    "name": "publish",
+                    "payload": {"arguments": {"draft": True}},
+                    "capabilities": ["workspace.write"],
+                    "created_at": "2026-07-17T08:00:00Z",
+                }
+            ],
+            "approvals": [
+                {
+                    "type": "approval.decided",
+                    "decision": {
+                        "approved": True,
+                        "request_id": "approval_a",
+                        "reason": "reviewed",
+                        "decided_at": "2026-07-17T08:00:01Z",
+                    },
+                }
+            ],
+            "artifacts": [
+                {
+                    "id": "artifact_a",
+                    "kind": "result",
+                    "name": "output",
+                    "media_type": "text/plain",
+                    "parts": [{"type": "text", "content": "old"}],
+                    "timestamp": "2026-07-17T08:00:02Z",
+                }
+            ],
+            "final_task": {
+                "id": "task_a",
+                "state": "completed",
+                "messages": [
+                    {
+                        "id": "message_a",
+                        "role": "agent",
+                        "parts": [{"type": "text", "content": "old"}],
+                        "timestamp": "2026-07-17T08:00:03Z",
+                    }
+                ],
+                "artifacts": [],
+                "metadata": {},
+                "flow_state": {},
+                "created_at": "2026-07-17T08:00:00Z",
+            },
+        }
+    )
+    candidate_data = copy.deepcopy(baseline.to_dict())
+    candidate_data["actions"][0]["payload"]["arguments"]["draft"] = False
+    candidate_data["approvals"][0]["decision"]["approved"] = False
+    candidate_data["artifacts"][0]["parts"][0]["content"] = "new"
+    candidate_data["final_task"]["messages"][0]["parts"][0]["content"] = "new"
+
+    result = diff_run_reports(baseline, candidate_data)
+
+    assert set(result.changed_sections) == {
+        "actions",
+        "approvals",
+        "artifacts",
+        "final_task",
+    }
+
+
+def test_numeric_tolerances_are_opt_in_and_do_not_treat_booleans_as_numbers() -> None:
+    baseline = RunReport.from_dict(
+        {
+            "metrics": [
+                {
+                    "provider": "mock",
+                    "model": "mock",
+                    "latency_ms": 100.0,
+                    "usage": {"total_tokens": 10},
+                    "cached": False,
+                }
+            ]
+        }
+    )
+    candidate = RunReport.from_dict(
+        {
+            "metrics": [
+                {
+                    "provider": "mock",
+                    "model": "mock",
+                    "latency_ms": 104.0,
+                    "usage": {"total_tokens": 10},
+                    "cached": 0,
+                }
+            ]
+        }
+    )
+    config = RunReportDiffConfig(
+        sections=("metrics",),
+        tolerances=(
+            RunReportTolerance(
+                "/metrics/*/latency_ms",
+                absolute_tolerance=5.0,
+            ),
+            RunReportTolerance(
+                "/metrics/*/cached",
+                absolute_tolerance=1.0,
+            ),
+        ),
+    )
+
+    result = diff_run_reports(baseline, candidate, config=config)
+
+    assert [difference.path for difference in result.differences] == ["/metrics/0/cached"]
+
+    candidate.metrics[0]["cached"] = False
+    assert diff_run_reports(baseline, candidate, config=config).matches
+
+    candidate.metrics[0]["latency_ms"] = 106.0
+    outside_tolerance = diff_run_reports(baseline, candidate, config=config)
+    assert [difference.path for difference in outside_tolerance.differences] == ["/metrics/0/latency_ms"]
+
+
+def test_numeric_json_equivalence_and_large_integer_tolerances_do_not_overflow() -> None:
+    config = RunReportDiffConfig(
+        sections=("metadata",),
+        tolerances=(
+            RunReportTolerance(
+                "/metadata/huge",
+                relative_tolerance=0.000001,
+            ),
+        ),
+    )
+    huge = 10**1000
+
+    result = diff_run_reports(
+        {"metadata": {"number": 1, "huge": huge}},
+        {"metadata": {"number": 1.0, "huge": huge + 1}},
+        config=config,
+    )
+
+    assert result.matches
+
+
+def test_custom_ignore_paths_and_strict_volatile_comparison() -> None:
+    baseline = _report_payload(run_id="run_a", task_id="task_a", event_id="event_a")
+    candidate = _report_payload(run_id="run_b", task_id="task_b", event_id="event_b")
+    candidate["events"][0]["payload"]["debug"] = {"request": "candidate-only"}
+    baseline["events"][0]["payload"]["debug"] = {"request": "baseline-only"}
+
+    ignored = RunReportDiffConfig(
+        sections=("events",),
+        ignore_paths=("/events/*/payload/debug",),
+    )
+    assert diff_run_reports(baseline, candidate, config=ignored).matches
+
+    strict = RunReportDiffConfig(
+        sections=("events",),
+        normalize_volatile=False,
+        ignore_paths=("/events/*/payload/debug",),
+    )
+    result = diff_run_reports(baseline, candidate, config=strict)
+    assert not result.matches
+    assert "/events/0/event_id" in {difference.path for difference in result.differences}
+
+
+def test_missing_and_explicit_null_are_distinct_in_serialized_differences() -> None:
+    added = diff_run_reports(
+        {"metadata": {}},
+        {"metadata": {"flag": None}},
+        config=RunReportDiffConfig(sections=("metadata",)),
+    ).to_dict()
+    difference = added["differences"][0]
+
+    assert difference["kind"] == "added"
+    assert "baseline" not in difference
+    assert difference["candidate"] is None
+
+    removed = diff_run_reports(
+        {"metadata": {"flag": None}},
+        {"metadata": {}},
+        config=RunReportDiffConfig(sections=("metadata",)),
+    ).to_dict()["differences"][0]
+    assert removed["kind"] == "removed"
+    assert removed["baseline"] is None
+    assert "candidate" not in removed
+
+
+def test_dictionary_order_is_ignored_but_list_order_is_behavioral() -> None:
+    baseline = {"metadata": {"mapping": {"a": 1, "b": 2}, "order": ["a", "b"]}}
+    candidate = {"metadata": {"order": ["a", "b"], "mapping": {"b": 2, "a": 1}}}
+    config = RunReportDiffConfig(sections=("metadata",))
+
+    assert diff_run_reports(baseline, candidate, config=config).matches
+
+    candidate["metadata"]["order"] = ["b", "a"]
+    result = diff_run_reports(baseline, candidate, config=config)
+    assert [difference.path for difference in result.differences] == [
+        "/metadata/order/0",
+        "/metadata/order/1",
+    ]
+
+
+def test_sources_are_not_mutated_and_replay_and_old_dict_inputs_are_supported() -> None:
+    baseline = _report_payload(run_id="run_a", task_id="task_a", event_id="event_a")
+    candidate = copy.deepcopy(baseline)
+    original = copy.deepcopy(baseline)
+    replay = RunReplay(RunReport.from_dict(candidate))
+
+    assert diff_run_reports(baseline, replay).matches
+    assert baseline == original
+    assert normalize_run_report({"events": []}) == normalize_run_report(RunReport.from_dict({"events": []}))
+
+
+def test_redacted_formatting_and_assertion_errors_do_not_expose_secrets() -> None:
+    config = RunReportDiffConfig(sections=("metadata",))
+    result = diff_run_reports(
+        {"metadata": {"api_key": "baseline-secret"}},
+        {"metadata": {"api_key": "candidate-secret"}},
+        config=config,
+    )
+
+    assert "baseline-secret" in str(result.to_dict())
+    redacted = result.to_dict(redaction_policy=RedactionPolicy())
+    assert redacted["differences"][0]["baseline"] == "[REDACTED]"
+    formatted = result.format()
+    assert "baseline-secret" not in formatted
+    assert "candidate-secret" not in formatted
+    assert "[REDACTED]" in formatted
+
+    with pytest.raises(AssertionError, match="Run reports differ") as exc_info:
+        assert_run_matches(
+            {"metadata": {"api_key": "baseline-secret"}},
+            {"metadata": {"api_key": "candidate-secret"}},
+            config=config,
+        )
+    assert "baseline-secret" not in str(exc_info.value)
+
+    nested = diff_run_reports(
+        {"metadata": {"credentials": {"client_id": "baseline-client"}}},
+        {"metadata": {"credentials": {"client_id": "candidate-client"}}},
+        config=config,
+    ).format()
+    assert "baseline-client" not in nested
+    assert "candidate-client" not in nested
+    assert "[REDACTED]" in nested
+
+
+def test_json_pointer_escapes_application_keys() -> None:
+    result = diff_run_reports(
+        {"metadata": {"a/b~c": "old"}},
+        {"metadata": {"a/b~c": "new"}},
+        config=RunReportDiffConfig(sections=("metadata",)),
+    )
+
+    assert result.differences[0].path == "/metadata/a~1b~0c"
+
+
+def test_invalid_diff_configuration_is_rejected() -> None:
+    with pytest.raises(ValueError, match="Unknown run-report sections"):
+        RunReportDiffConfig(sections=("unknown",))  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="RFC 6901"):
+        RunReportDiffConfig(ignore_paths=("events.*.timestamp",))
+    with pytest.raises(ValueError, match="Invalid RFC 6901 escape"):
+        RunReportDiffConfig(ignore_paths=("/events/~2/timestamp",))
+    with pytest.raises(ValueError, match="non-negative"):
+        RunReportTolerance("/metrics/*/latency_ms", absolute_tolerance=-1)
+
+
+def _report_payload(
+    *,
+    run_id: str,
+    task_id: str,
+    event_id: str,
+    message_id: str = "message",
+    timestamp: str = "2026-07-17T08:00:00Z",
+    business_id: str = "order-42",
+    business_timestamp: str = "2030-01-01T00:00:00Z",
+) -> dict:
+    return {
+        "context": {
+            "run_id": run_id,
+            "session_id": f"session-{run_id}",
+            "trace_id": f"trace-{run_id}",
+            "agent_chain": ["tester"],
+            "permissions": {},
+            "budget": {},
+            "metadata": {},
+            "created_at": timestamp,
+        },
+        "events": [
+            {
+                "event_id": event_id,
+                "type": "tool.result",
+                "run_id": run_id,
+                "task_id": task_id,
+                "sequence": 1,
+                "timestamp": timestamp,
+                "metadata": {"source_type": "task_llm_stream"},
+                "payload": {
+                    "task_id": task_id,
+                    "timestamp": timestamp,
+                    "result": {
+                        "id": business_id,
+                        "timestamp": business_timestamp,
+                    },
+                },
+            }
+        ],
+        "final_task": {
+            "id": task_id,
+            "state": "completed",
+            "messages": [
+                {
+                    "id": message_id,
+                    "role": "agent",
+                    "parts": [{"type": "text", "content": "done"}],
+                    "timestamp": timestamp,
+                }
+            ],
+            "artifacts": [],
+            "metadata": {
+                "run_id": run_id,
+                "session_id": f"session-{run_id}",
+                "trace_id": f"trace-{run_id}",
+                "state_history": [
+                    {
+                        "previous_state": "working",
+                        "new_state": "completed",
+                        "timestamp": timestamp,
+                    }
+                ],
+            },
+            "flow_state": {},
+            "created_at": timestamp,
+        },
+        "metadata": {"suite": "regression"},
+    }
+
+
+async def _record_mock_run(run_id: str) -> RunReport:
+    agent = Agent(
+        AgentCard(
+            name="regression-agent",
+            description="Provider-free run comparison fixture",
+            url="runtime://regression-agent",
+        ),
+        llm=create_llm("mock", default_response="stable answer"),
+        verbosity=0,
+    )
+    task = Task.create_infer(prompt="produce the stable answer")
+    context = RunContext(
+        run_id=run_id,
+        session_id=f"session-{run_id}",
+        trace_id=f"trace-{run_id}",
+        agent_chain=["test-client"],
+    )
+    context.attach_to_task(task)
+    recorder = RunRecorder(context=context)
+    async for event in agent.handle_task_streaming(task):
+        await recorder.record_task_event(event)
+    return recorder.to_report(metadata={"suite": "recorded-regression"})


### PR DESCRIPTION
**Normalized run-report regression diffing**
  - Added `RunReportDiff`, `RunReportDifference`, `RunReportDiffConfig`, `RunReportTolerance`, `ALL_RUN_REPORT_SECTIONS`, `normalize_run_report()`, `diff_run_reports()`, and `assert_run_matches()` for comparing baseline and candidate reports. Regression suites normally record final reports, but the helpers do not require a particular task lifecycle state.
  - Comparisons normalize known ProtoLink runtime-envelope identifiers, timestamps, and sequence counters while preserving repeated identifier relationships, report structured path-level changes, and support configurable ignored paths and numeric tolerances without mutating the source reports. Application-owned payloads and report metadata remain exact by default.
  - Added `protolink run diff BASELINE CANDIDATE --store runs.db [--json]` for offline comparison of two stored reports. The command exits `0` for a match, `1` for behavioral changes, and `2` when either report is missing.
  - Text and JSON CLI diff output apply the default redaction policy to compared values. The core `RunReportDiff.to_dict()` API remains raw unless the caller supplies a redaction policy.
  - Added the provider-free `examples/run_regression_diff.py` walkthrough for pinning a baseline, detecting a changed result, and using the assertion helper in tests.
